### PR TITLE
feat: add schema tools

### DIFF
--- a/scripts/test_main_tools.py
+++ b/scripts/test_main_tools.py
@@ -94,6 +94,19 @@ async def main(urn_or_query: Optional[str]) -> None:
                 indent=2,
             )
         )
+        _divider()
+        print(f"Getting versioned_dataset: {urn}")
+        print(
+            json.dumps(
+                await _call_tool(
+                    mcp_client,
+                    "get_versioned_dataset",
+                    dataset_urn=urn_or_query,
+                    semantic_version="0.0.0",
+                ),
+                indent=2,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -1302,3 +1302,59 @@ query GetEntityLineage($input: SearchAcrossLineageInput!) {
     }
   }
 }
+
+
+query getSchemaVersionList($input: GetSchemaVersionListInput!) {
+  getSchemaVersionList(input: $input) {
+    latestVersion {
+      semanticVersion
+      versionStamp
+      __typename
+    }
+    semanticVersionList {
+      semanticVersion
+      versionStamp
+      __typename
+    }
+    __typename
+  }
+}
+
+
+query getVersionedDataset($urn: String!, $versionStamp: String) {
+  versionedDataset(urn: $urn, versionStamp: $versionStamp) {
+    schema {
+      fields {
+        fieldPath
+        jsonPath
+        nullable
+        description
+        type
+        nativeDataType
+        recursive
+        isPartOfKey
+        isPartitioningKey
+        __typename
+      }
+      lastObserved
+      __typename
+    }
+    editableSchemaMetadata {
+      editableSchemaFieldInfo {
+        fieldPath
+        description
+        globalTags {
+          ...globalTagsFields
+          __typename
+        }
+        glossaryTerms {
+          ...glossaryTerms
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,6 +10,7 @@ from mcp_server_datahub.mcp_server import (
     get_dataset_queries,
     get_entity,
     get_lineage,
+    get_versioned_dataset,
     mcp,
     search,
     with_datahub_client,
@@ -131,3 +132,9 @@ async def test_get_dataset_queries() -> None:
     assert res is not None
     assert res.get("queries") is not None
     assert len(res.get("queries")) > 0
+
+
+@pytest.mark.anyio
+async def test_get_versioned_datset() -> None:
+    res = await get_versioned_dataset.fn(_test_urn, "0.0.0")
+    assert res is not None


### PR DESCRIPTION
## Changes

- Add listing schema_versions(latest_version, versions) functionality to response of `get_entity()`.
- Add `get_versioned_dataset` tool for retrieving schema by version.

## Motivation

- Getting schema by the version let LLM detect changed columns and help fix outdated queries.
- This will boost productivity compared to manual methods.


## Tests

I defined a test scenario and tried the available MCP hosts and models. Since I didn’t select them based on specific criteria, please suggest any additional tests.

### Settings

- DataHub: Self hosted (v1.1.0)

- Test Dataset in DataHub
    - Type: Athena Table
    - Name: sample.users
    - Schema Histories: (`email` is renamed to `email_address` at v0.1.0)
        |  version    |  col1     |  col2    |  col3    | col4     |
        | ---|---|---|---|---|
        | 0.0.0 |  id |  name | email | created_at |
        | 0.1.0 |  id |  name | email_address | created_at |

- Test Scenario
  - There are two schema versions: `0.0.0` and `0.1.0` on `sample.users` table.
  - The `email` column is renamed to `email_address` on `0.1.0`
  - Confirm the LLM can detect differences between two schemas.
  

- Prompt(common)

    ```
    === Instructions ===
    You are a DataHub AI agent. Your job is to answer user questions about DataHub metadata by calling the datahub MCP (Model Context Protocol) methods.
    
    === Input ===
    Can you tell me the schema differences between the latest version and the previous version of the Athena named sample.users?
    ```
    note: To also test that the version list is retrieved correctly, the prompt uses `latest` and `previous` instead of specifying concrete versions.

### Test Result Summary

| MCP Host |  Model | Worked Expectedly | Notes |
|---|---|---|---|
| Claude Desktop | Claude Sonet 4 |  Y | - |
| Cursor |  Claude Sonet 4 |  Y |  'search' tool errored few times, recovered itself and succeeded. |
| Cursor |  gemini-2.5-pro |  N |  Failed: argument not supported |
| Cursor |  GPT-4.1 | Y |  'search' tool errored few times, recovered itself and succeeded. |
| Cline | GPT-4.1 | Y | - |

### Claude Desktop

#### Claude Sonnet4

![스크린샷 2025-06-12 오후 6 10 16](https://github.com/user-attachments/assets/8fa035f2-d7df-4a89-b8e5-edb33789d52e)


### Cursor

#### Claude Sonnet 4

![스크린샷 2025-06-12 오후 6 06 32](https://github.com/user-attachments/assets/52d15097-3b1d-4493-96fe-de6eeb5f49f5)

#### gemini-2.5-pro

- **Failed**

![스크린샷 2025-06-12 오후 6 03 54](https://github.com/user-attachments/assets/2f86d191-ef7a-4283-bd16-060dff462b95)


#### GPT-4.1

![스크린샷 2025-06-12 오후 5 56 34](https://github.com/user-attachments/assets/34047d0e-a319-426f-b894-9b6de0673ce5)



### CLINE (VS Code)

#### GPT-4.1

![스크린샷 2025-06-12 오후 5 47 24](https://github.com/user-attachments/assets/2a5fa349-e86e-479d-b33f-9ecca63bcaba)
![스크린샷 2025-06-12 오후 5 48 17](https://github.com/user-attachments/assets/9047f32e-96a1-4151-a863-b42baa1f1bc6)



note: This PR is recreated from #10