### PR TITLE
feat: Add comprehensive write operations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
 # mcp-server-datahub
 
-A [Model Context Protocol](https://modelcontextprotocol.io/) server implementation for [DataHub](https://datahubproject.io/).
-This enables AI agents to query DataHub for metadata and context about your data ecosystem.
+A comprehensive [Model Context Protocol](https://modelcontextprotocol.io/) server implementation for [DataHub](https://datahubproject.io/).
+This enables AI agents to both query and manage DataHub metadata, providing full read and write capabilities for your data ecosystem.
 
 Supports both DataHub Core and DataHub Cloud.
 
 ## Features
 
-- Searching across all entity types and using arbitrary filters
-- Fetching metadata for any entity
-- Traversing the lineage graph, both upstream and downstream
-- Listing SQL queries associated with a dataset
+### Read Operations
+- Search across all entity types with advanced filtering
+- Fetch detailed metadata for any entity
+- Traverse the lineage graph, both upstream and downstream
+- List SQL queries associated with datasets
+
+### Write Operations
+- Update entity and field descriptions
+- Create and manage tags
+- Add and remove tags from entities and fields
+- Batch tag operations for multiple entities
+- Create and manage business domains
+- Assign entities to domains
+- Create and manage glossary terms
+- Link glossary terms to entities and fields
+- Add owners to entities
 
 ## Demo
 

--- a/src/mcp_server_datahub/gql/mutations.gql
+++ b/src/mcp_server_datahub/gql/mutations.gql
@@ -1,0 +1,69 @@
+# Mutation for creating tags
+mutation createTag($input: CreateTagInput!) {
+  createTag(input: $input)
+}
+
+# Mutation for updating entity descriptions
+mutation updateDescription($input: DescriptionUpdateInput!) {
+  updateDescription(input: $input)
+}
+
+# Mutation for adding tags to an entity
+mutation addTags($input: AddTagsInput!) {
+  addTags(input: $input)
+}
+
+# Mutation for removing a tag from an entity
+mutation removeTag($input: TagAssociationInput!) {
+  removeTag(input: $input)
+}
+
+# Mutation for batch adding tags to multiple entities
+mutation batchAddTags($input: BatchAddTagsInput!) {
+  batchAddTags(input: $input)
+}
+
+# Mutation for batch removing tags from multiple entities
+mutation batchRemoveTags($input: BatchRemoveTagsInput!) {
+  batchRemoveTags(input: $input)
+}
+
+# Mutation for setting the domain of an entity
+mutation setDomain($entityUrn: String!, $domainUrn: String!) {
+  setDomain(entityUrn: $entityUrn, domainUrn: $domainUrn)
+}
+
+# Mutation for unsetting the domain of an entity
+mutation unsetDomain($entityUrn: String!) {
+  unsetDomain(entityUrn: $entityUrn)
+}
+
+# Mutation for adding owners to an entity
+mutation addOwners($input: AddOwnersInput!) {
+  addOwners(input: $input)
+}
+
+# Mutation for removing owners from an entity - not available in DataHub API
+# mutation removeOwners($input: RemoveOwnersInput!) {
+#   removeOwners(input: $input)
+# }
+
+# Mutation for adding glossary terms to an entity
+mutation addTerms($input: AddTermsInput!) {
+  addTerms(input: $input)
+}
+
+# Mutation for removing glossary terms from an entity - using removeTerm for single term removal
+mutation removeTerm($input: TermAssociationInput!) {
+  removeTerm(input: $input)
+}
+
+# Mutation for creating a new domain
+mutation createDomain($input: CreateDomainInput!) {
+  createDomain(input: $input)
+}
+
+# Mutation for creating a new glossary term
+mutation createGlossaryTerm($input: CreateGlossaryEntityInput!) {
+  createGlossaryTerm(input: $input)
+}

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import jmespath
 from datahub.errors import ItemNotFoundError
-from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
 from datahub.sdk.main_client import DataHubClient
 from datahub.sdk.search_client import compile_filters
 from datahub.sdk.search_filters import Filter, FilterDsl
@@ -61,9 +61,10 @@ def _execute_graphql(
     if _is_datahub_cloud(graph):
         query = _enable_cloud_fields(query)
 
-    return graph.execute_graphql(
+    result = graph.execute_graphql(
         query=query, variables=variables, operation_name=operation_name
     )
+    return result
 
 
 def _inject_urls_for_urns(
@@ -88,6 +89,7 @@ entity_details_fragment_gql = (
 ).read_text()
 
 queries_gql = (pathlib.Path(__file__).parent / "gql/queries.gql").read_text()
+mutations_gql = (pathlib.Path(__file__).parent / "gql/mutations.gql").read_text()
 
 
 def _clean_gql_response(response: Any) -> Any:
@@ -313,6 +315,657 @@ def get_lineage(urn: str, upstream: bool, max_hops: int = 1) -> dict:
     return lineage
 
 
+@mcp.tool(
+    description="""Update the description of an entity.
+    
+Supports updating descriptions for datasets, schema fields, containers, charts, dashboards, and other entities.
+For schema fields, use the format: 'urn:li:schemaField:(dataset_urn,field_name)'
+
+Args:
+    urn: The URN of the entity to update
+    description: The new description text
+    subResource: Optional sub-resource URN (for schema fields)
+"""
+)
+def update_description(urn: str, description: str, subResource: str = None) -> dict:
+    client = get_client()
+    
+    # Prepare the input for the mutation according to DescriptionUpdateInput schema
+    mutation_input = {
+        "resourceUrn": urn,
+        "description": description
+    }
+    
+    # Add subResource and subResourceType if provided
+    if subResource:
+        mutation_input["subResource"] = subResource
+        mutation_input["subResourceType"] = "DATASET_FIELD"  # Assuming schema field for now
+    
+    # Execute the GraphQL mutation
+    variables = {"input": mutation_input}
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="updateDescription"
+    )
+    
+    # Handle the response - mutations might return data differently than queries
+    if result and "updateDescription" in result:
+        # Direct access like other tools do
+        success_value = result["updateDescription"]
+        return {"success": success_value, "urn": urn, "subResource": subResource}
+    elif isinstance(result, dict) and "data" in result and "updateDescription" in result["data"]:
+        # Nested structure
+        success_value = result["data"]["updateDescription"]
+        return {"success": success_value, "urn": urn, "subResource": subResource}
+    else:
+        # Handle unexpected response structure
+        return {"error": "Unexpected response structure", "result": result}
+
+
+@mcp.tool(
+    description="""Add tags to an entity.
+    
+Args:
+    urn: The URN of the entity to tag
+    tags: List of tag URNs to add (e.g., ['urn:li:tag:PII', 'urn:li:tag:Sensitive'])
+    subResource: Optional sub-resource URN (for schema fields)
+"""
+)
+def add_tags(urn: str, tags: List[str], subResource: str = None) -> dict:
+    client = get_client()
+    
+    # Convert simple tag names to tag URNs if needed
+    tag_urns = []
+    for tag in tags:
+        if tag.startswith("urn:li:tag:"):
+            tag_urns.append(tag)
+        else:
+            tag_urns.append(f"urn:li:tag:{tag}")
+    
+    # Prepare the input for the mutation
+    mutation_input = {
+        "resourceUrn": urn,
+        "tagUrns": tag_urns
+    }
+    
+    # Add subResource if provided (for schema fields, we need to specify the subResourceType)
+    if subResource:
+        mutation_input["subResource"] = subResource
+        mutation_input["subResourceType"] = "DATASET_FIELD"
+    
+    # Execute the GraphQL mutation
+    variables = {"input": mutation_input}
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="addTags"
+    )
+    
+    # Extract the mutation result from the response (handle different response structures)
+    if result and "addTags" in result:
+        success_value = result["addTags"]
+    elif isinstance(result, dict) and "data" in result and "addTags" in result["data"]:
+        success_value = result["data"]["addTags"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {"success": success_value, "urn": urn, "tags_added": tag_urns}
+
+
+@mcp.tool(
+    description="""Remove a tag from an entity.
+    
+Args:
+    urn: The URN of the entity
+    tag: Tag URN to remove (e.g., 'urn:li:tag:PII')
+    subResource: Optional sub-resource URN (for schema fields)
+"""
+)
+def remove_tag(urn: str, tag: str, subResource: str = None) -> dict:
+    client = get_client()
+    
+    # Convert simple tag name to tag URN if needed
+    if not tag.startswith("urn:li:tag:"):
+        tag = f"urn:li:tag:{tag}"
+    
+    # Prepare the input for the mutation
+    mutation_input = {
+        "resourceUrn": urn,
+        "tagUrn": tag
+    }
+    
+    # Add subResource if provided (for schema fields, we need to specify the subResourceType)
+    if subResource:
+        mutation_input["subResource"] = subResource
+        mutation_input["subResourceType"] = "DATASET_FIELD"
+    
+    # Execute the GraphQL mutation
+    variables = {"input": mutation_input}
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="removeTag"
+    )
+    
+    # Extract the mutation result from the response (handle different response structures)
+    if result and "removeTag" in result:
+        success_value = result["removeTag"]
+    elif isinstance(result, dict) and "data" in result and "removeTag" in result["data"]:
+        success_value = result["data"]["removeTag"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {"success": success_value, "urn": urn, "tag_removed": tag}
+
+
+@mcp.tool(
+    description="""Add tags to multiple entities at once.
+    
+Args:
+    entities: List of entity URNs to tag
+    tags: List of tag URNs to add to all entities
+"""
+)
+def batch_add_tags(entities: List[str], tags: List[str]) -> dict:
+    client = get_client()
+    
+    # Convert simple tag names to tag URNs if needed
+    tag_urns = []
+    for tag in tags:
+        if tag.startswith("urn:li:tag:"):
+            tag_urns.append(tag)
+        else:
+            tag_urns.append(f"urn:li:tag:{tag}")
+    
+    # Prepare the input for the mutation
+    mutation_input = {
+        "resources": [{"resourceUrn": urn} for urn in entities],
+        "tagUrns": tag_urns
+    }
+    
+    # Execute the GraphQL mutation
+    variables = {"input": mutation_input}
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="batchAddTags"
+    )
+    
+    # Extract the mutation result from the response (handle different response structures)
+    if result and "batchAddTags" in result:
+        success_value = result["batchAddTags"]
+    elif isinstance(result, dict) and "data" in result and "batchAddTags" in result["data"]:
+        success_value = result["data"]["batchAddTags"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {
+        "success": success_value, 
+        "entities": entities,
+        "tags_added": tag_urns
+    }
+
+
+@mcp.tool(
+    description="""Remove tags from multiple entities at once.
+    
+Args:
+    entities: List of entity URNs to remove tags from
+    tags: List of tag URNs to remove from all entities
+"""
+)
+def batch_remove_tags(entities: List[str], tags: List[str]) -> dict:
+    client = get_client()
+    
+    # Convert simple tag names to tag URNs if needed
+    tag_urns = []
+    for tag in tags:
+        if tag.startswith("urn:li:tag:"):
+            tag_urns.append(tag)
+        else:
+            tag_urns.append(f"urn:li:tag:{tag}")
+    
+    # Prepare the input for the mutation
+    mutation_input = {
+        "resources": [{"resourceUrn": urn} for urn in entities],
+        "tagUrns": tag_urns
+    }
+    
+    # Execute the GraphQL mutation
+    variables = {"input": mutation_input}
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="batchRemoveTags"
+    )
+    
+    # Extract the mutation result from the response (handle different response structures)
+    if result and "batchRemoveTags" in result:
+        success_value = result["batchRemoveTags"]
+    elif isinstance(result, dict) and "data" in result and "batchRemoveTags" in result["data"]:
+        success_value = result["data"]["batchRemoveTags"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {
+        "success": success_value, 
+        "entities": entities,
+        "tags_removed": tag_urns
+    }
+
+
+@mcp.tool(
+    description="""Create a new tag in DataHub.
+    
+Creates a new tag that can then be applied to datasets, fields, or other entities.
+Requires the 'Manage Tags' or 'Create Tags' Platform Privilege.
+
+Args:
+    name: Display name for the tag (required)
+    description: Optional description for the tag
+    id: Optional custom id to use as the primary key identifier. If not provided, a random UUID will be generated.
+"""
+)
+def create_tag(name: str, description: str = None, id: str = None) -> dict:
+    client = get_client()
+    
+    # Prepare the input for the createTag mutation
+    variables = {
+        "input": {
+            "name": name
+        }
+    }
+    
+    # Add optional fields if provided
+    if description:
+        variables["input"]["description"] = description
+    if id:
+        variables["input"]["id"] = id
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="createTag"
+    )
+    
+    # Handle the response - createTag returns the URN of the created tag
+    if result and "createTag" in result:
+        tag_urn = result["createTag"]
+        return {"success": True, "tag_urn": tag_urn, "name": name, "description": description}
+    elif isinstance(result, dict) and "data" in result and "createTag" in result["data"]:
+        tag_urn = result["data"]["createTag"]
+        return {"success": True, "tag_urn": tag_urn, "name": name, "description": description}
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+
+
+@mcp.tool(
+    description="""Set the domain for an entity.
+    
+Assigns an entity to a business domain for organizational purposes.
+Domains help organize data assets by business area, team, or function.
+
+Args:
+    urn: The URN of the entity to assign to a domain
+    domain_urn: The URN of the domain to assign (e.g., 'urn:li:domain:marketing')
+"""
+)
+def set_domain(urn: str, domain_urn: str) -> dict:
+    client = get_client()
+    
+    # Prepare the variables for the setDomain mutation
+    variables = {
+        "entityUrn": urn,
+        "domainUrn": domain_urn
+    }
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="setDomain"
+    )
+    
+    # Handle the response
+    if result and "setDomain" in result:
+        success_value = result["setDomain"]
+    elif isinstance(result, dict) and "data" in result and "setDomain" in result["data"]:
+        success_value = result["data"]["setDomain"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {"success": success_value, "urn": urn, "domain_urn": domain_urn}
+
+
+@mcp.tool(
+    description="""Remove the domain from an entity.
+    
+Unassigns an entity from its current domain.
+
+Args:
+    urn: The URN of the entity to remove from its domain
+"""
+)
+def unset_domain(urn: str) -> dict:
+    client = get_client()
+    
+    # Prepare the variables for the unsetDomain mutation
+    variables = {
+        "entityUrn": urn
+    }
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="unsetDomain"
+    )
+    
+    # Handle the response
+    if result and "unsetDomain" in result:
+        success_value = result["unsetDomain"]
+    elif isinstance(result, dict) and "data" in result and "unsetDomain" in result["data"]:
+        success_value = result["data"]["unsetDomain"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {"success": success_value, "urn": urn}
+
+
+@mcp.tool(
+    description="""Add owners to an entity.
+    
+Assigns ownership to datasets, dashboards, or other entities.
+Supports different owner types like Technical Owner, Business Owner, etc.
+
+Args:
+    urn: The URN of the entity to add owners to
+    owner_urns: List of owner URNs (e.g., ['urn:li:corpuser:john.doe', 'urn:li:corpGroup:data-team'])
+    owner_type: Type of ownership - 'TECHNICAL_OWNER', 'BUSINESS_OWNER', 'DATA_STEWARD', 'DATAOWNER', etc.
+"""
+)
+def add_owners(urn: str, owner_urns: List[str], owner_type: str = None) -> dict:
+    client = get_client()
+    
+    # Prepare the owners list with ownership type
+    owners = []
+    for owner_urn in owner_urns:
+        # Determine owner entity type based on URN
+        if ":corpuser:" in owner_urn:
+            owner_entity_type = "CORP_USER"
+        elif ":corpGroup:" in owner_urn:
+            owner_entity_type = "CORP_GROUP"
+        else:
+            owner_entity_type = "CORP_USER"  # Default fallback
+            
+        owner_data = {
+            "ownerUrn": owner_urn,
+            "ownerEntityType": owner_entity_type
+        }
+        
+        # Only add ownership type if specified and valid
+        if owner_type:
+            # Map common owner types to their system URNs
+            ownership_type_mapping = {
+                "TECHNICAL_OWNER": "urn:li:ownershipType:__system__technical_owner",
+                "BUSINESS_OWNER": "urn:li:ownershipType:__system__business_owner", 
+                "DATA_STEWARD": "urn:li:ownershipType:__system__data_steward",
+                "DATAOWNER": "urn:li:ownershipType:__system__dataowner"
+            }
+            
+            if owner_type in ownership_type_mapping:
+                owner_data["ownershipTypeUrn"] = ownership_type_mapping[owner_type]
+        # If no owner_type provided, don't include ownershipTypeUrn to use default
+        
+        owners.append(owner_data)
+    
+    # Prepare the input for the addOwners mutation
+    variables = {
+        "input": {
+            "resourceUrn": urn,
+            "owners": owners
+        }
+    }
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="addOwners"
+    )
+    
+    # Handle the response
+    if result and "addOwners" in result:
+        success_value = result["addOwners"]
+    elif isinstance(result, dict) and "data" in result and "addOwners" in result["data"]:
+        success_value = result["data"]["addOwners"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {"success": success_value, "urn": urn, "owners_added": owner_urns, "owner_type": owner_type}
+
+
+# Note: DataHub GraphQL API doesn't provide a removeOwners mutation
+# Individual owners can be removed using the removeOwner mutation (single owner at a time)
+
+
+@mcp.tool(
+    description="""Add glossary terms to an entity.
+    
+Links business glossary terms to datasets, fields, or other entities.
+Helps provide business context and standardized definitions.
+
+Args:
+    urn: The URN of the entity to add terms to
+    term_urns: List of glossary term URNs (e.g., ['urn:li:glossaryTerm:CustomerData', 'urn:li:glossaryTerm:Revenue'])
+    subResource: Optional sub-resource URN (for schema fields)
+"""
+)
+def add_terms(urn: str, term_urns: List[str], subResource: str = None) -> dict:
+    client = get_client()
+    
+    # Prepare the input for the addTerms mutation
+    mutation_input = {
+        "resourceUrn": urn,
+        "termUrns": term_urns
+    }
+    
+    # Add subResource if provided (for schema fields)
+    if subResource:
+        mutation_input["subResource"] = subResource
+        mutation_input["subResourceType"] = "DATASET_FIELD"
+    
+    variables = {"input": mutation_input}
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="addTerms"
+    )
+    
+    # Handle the response
+    if result and "addTerms" in result:
+        success_value = result["addTerms"]
+    elif isinstance(result, dict) and "data" in result and "addTerms" in result["data"]:
+        success_value = result["data"]["addTerms"]
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+    
+    return {"success": success_value, "urn": urn, "terms_added": term_urns}
+
+
+@mcp.tool(
+    description="""Remove glossary terms from an entity.
+    
+Removes business glossary term associations from datasets, fields, or other entities.
+Note: This removes terms one at a time using the removeTerm mutation.
+
+Args:
+    urn: The URN of the entity to remove terms from
+    term_urns: List of glossary term URNs to remove
+    subResource: Optional sub-resource URN (for schema fields)
+"""
+)
+def remove_terms(urn: str, term_urns: List[str], subResource: str = None) -> dict:
+    client = get_client()
+    
+    results = []
+    errors = []
+    
+    # Remove terms one by one since DataHub only supports single term removal
+    for term_urn in term_urns:
+        # Prepare the input for the removeTerm mutation
+        mutation_input = {
+            "resourceUrn": urn,
+            "termUrn": term_urn
+        }
+        
+        # Add subResource if provided (for schema fields)
+        if subResource:
+            mutation_input["subResource"] = subResource
+            mutation_input["subResourceType"] = "DATASET_FIELD"
+        
+        variables = {"input": mutation_input}
+        
+        try:
+            result = _execute_graphql(
+                client._graph,
+                query=mutations_gql,
+                variables=variables,
+                operation_name="removeTerm"
+            )
+            
+            # Handle the response
+            if result and "removeTerm" in result:
+                success_value = result["removeTerm"]
+                results.append({"term": term_urn, "success": success_value})
+            elif isinstance(result, dict) and "data" in result and "removeTerm" in result["data"]:
+                success_value = result["data"]["removeTerm"]
+                results.append({"term": term_urn, "success": success_value})
+            else:
+                errors.append({"term": term_urn, "error": f"Unexpected response structure: {result}"})
+        except Exception as e:
+            errors.append({"term": term_urn, "error": str(e)})
+    
+    # Return summary of results
+    successful_terms = [r["term"] for r in results if r.get("success")]
+    overall_success = len(successful_terms) == len(term_urns)
+    
+    return {
+        "success": overall_success, 
+        "urn": urn, 
+        "terms_removed": successful_terms,
+        "errors": errors if errors else None,
+        "summary": f"Removed {len(successful_terms)}/{len(term_urns)} terms"
+    }
+
+
+@mcp.tool(
+    description="""Create a new domain in DataHub.
+    
+Creates a new business domain for organizing data assets.
+Domains represent business areas, teams, or functional groups.
+
+Args:
+    name: Display name for the domain (required)
+    description: Optional description for the domain
+    id: Optional custom id. If not provided, will be generated from the name
+"""
+)
+def create_domain(name: str, description: str = None, id: str = None) -> dict:
+    client = get_client()
+    
+    # Prepare the input for the createDomain mutation
+    variables = {
+        "input": {
+            "name": name
+        }
+    }
+    
+    # Add optional fields
+    if description:
+        variables["input"]["description"] = description
+    if id:
+        variables["input"]["id"] = id
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="createDomain"
+    )
+    
+    # Handle the response
+    if result and "createDomain" in result:
+        domain_urn = result["createDomain"]
+        return {"success": True, "domain_urn": domain_urn, "name": name, "description": description}
+    elif isinstance(result, dict) and "data" in result and "createDomain" in result["data"]:
+        domain_urn = result["data"]["createDomain"]
+        return {"success": True, "domain_urn": domain_urn, "name": name, "description": description}
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+
+
+@mcp.tool(
+    description="""Create a new glossary term in DataHub.
+    
+Creates a new business glossary term for standardizing data definitions.
+Terms can then be linked to datasets and fields to provide business context.
+
+Args:
+    name: Display name for the glossary term (required)
+    definition: Business definition of the term
+    description: Optional additional description
+    id: Optional custom id. If not provided, will be generated from the name
+"""
+)
+def create_glossary_term(name: str, definition: str = None, description: str = None, id: str = None) -> dict:
+    client = get_client()
+    
+    # Prepare the input for the createGlossaryTerm mutation
+    variables = {
+        "input": {
+            "name": name
+        }
+    }
+    
+    # Add optional fields (using the CreateGlossaryEntityInput structure)
+    # DataHub CreateGlossaryEntityInput only supports 'description' field, not 'definition'
+    # If definition is provided, use it as the description
+    if definition:
+        variables["input"]["description"] = definition
+    elif description:
+        variables["input"]["description"] = description
+    if id:
+        variables["input"]["id"] = id
+    
+    result = _execute_graphql(
+        client._graph,
+        query=mutations_gql,
+        variables=variables,
+        operation_name="createGlossaryTerm"
+    )
+    
+    # Handle the response
+    if result and "createGlossaryTerm" in result:
+        term_urn = result["createGlossaryTerm"]
+        return {"success": True, "term_urn": term_urn, "name": name, "definition": definition, "description": description}
+    elif isinstance(result, dict) and "data" in result and "createGlossaryTerm" in result["data"]:
+        term_urn = result["data"]["createGlossaryTerm"]
+        return {"success": True, "term_urn": term_urn, "name": name, "definition": definition, "description": description}
+    else:
+        return {"success": False, "error": f"Unexpected response structure: {result}"}
+
+
 if __name__ == "__main__":
     import sys
 
@@ -322,7 +975,6 @@ if __name__ == "__main__":
         urn_or_query = sys.argv[1]
     else:
         urn_or_query = "*"
-        print("No query provided, will use '*' query")
     urn: Optional[str] = None
     if urn_or_query.startswith("urn:"):
         urn = urn_or_query


### PR DESCRIPTION
- Add 10 new write operation tools for complete metadata management
- Create mutations.gql with DataHub GraphQL mutations
- Implement tag management (create, add, remove, batch operations)
- Add description update capabilities for entities and fields
- Implement domain management (create, assign, unassign)
- Add glossary term management (create, link, unlink)
- Add owner management functionality
- Support field-level operations with subResource parameters
- Update README with comprehensive feature documentation
- Transform from read-only to full read/write DataHub MCP server

Tools added:
- create_tag, add_tags, remove_tag, batch_add_tags, batch_remove_tags
- update_description
- create_domain, set_domain, unset_domain
- create_glossary_term, add_terms, remove_terms
- add_owners