### PR TITLE
Add description field in get_entity call respone for data products.

### DIFF
--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -886,6 +886,13 @@ fragment entityPreview on Entity {
     }
     ...domainEntitiesFields
   }
+  ... on DataProduct {
+    urn
+    properties {
+      name
+      description
+    }
+  }
   # ... on Container {
   #     ...entityContainer
   # }


### PR DESCRIPTION
In our datahub UX design, we have separate the doc in hierarchy of domains and data products. It would be nice if we can get the description of data products in `get_entity` call as well

Tested locally verify that it is working
