### PR TITLE
add missing schema fields for graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/settings.local.json
 .graphqlrc.yml
+.cursor/*
 
 # Python-generated files
 __pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-server-datahub"
+name = "mano-datahub-mcp"
 dynamic = ["version"]
 description = "A Model Context Protocol (MCP) server for DataHub"
 readme = "README.md"
@@ -22,11 +22,11 @@ dev = [
 ]
 
 [project.urls]
-"Source" = "https://github.com/acryldata/mcp-server-datahub"
+"Source" = "https://github.com/mano1233/mcp-server-datahub"
 "Documentation" = "https://docs.datahub.com/docs/features/feature-guides/mcp"
 
 [project.scripts]
-mcp-server-datahub = "mcp_server_datahub.__main__:main"
+mano-datahub-mcp = "mcp_server_datahub.__main__:main"
 
 [build-system]
 requires = ["setuptools>=64", "setuptools-scm>=8"]

--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -500,7 +500,7 @@ fragment parentDomainsFields on ParentDomainsResult {
 fragment entityPreview on Entity {
   urn
   ... on Dataset {
-    name
+    name  
     platform {
       ...platformFields
     }
@@ -783,6 +783,64 @@ fragment entityPreview on Entity {
   }
   ... on GlossaryTerm {
     hierarchicalName
+    institutionalMemory {
+      elements {
+        url
+        label
+        
+      }
+    }
+    alias_of: relationships(input: {
+      types: ["IsA"],
+      direction: INCOMING
+    }) {
+      count
+      relationships {
+        entity {
+          urn
+          ... on GlossaryTerm {
+            properties {
+              name
+            }
+          }
+        }
+      }
+    }
+  aliased_to: relationships(input: {
+      types: ["IsA"],
+      direction: OUTGOING
+    }) {
+      count
+      relationships {
+        entity {
+          urn
+          ... on GlossaryTerm {
+            properties {
+              name
+            }
+          }
+        }
+      }
+    }
+    ownership {
+      owners {
+       owner {
+        ... on CorpUser {
+          username
+        }
+       }
+      ownershipType {
+        info {
+          name
+        }
+       }
+      }      
+     }
+    parentNodes {
+      nodes {
+        urn
+      }
+    }
     properties {
       name
       description
@@ -950,19 +1008,44 @@ fragment entityPreview on Entity {
   }
   ... on DataProduct {
     urn
+    institutionalMemory {
+      elements {
+        url
+        label
+        
+      }
+    }
+    ownership {
+      owners {
+       owner {
+        ... on CorpUser {
+          username
+        }
+       }
+      ownershipType {
+        info {
+          name
+        }
+       }
+      }      
+     }
     properties {
       name
       description
     }
-    entities(input: {
+    tables: entities(input: {
       start: 0
     query: "*"}) {
       searchResults {
         entity {
           urn
           ... on Dataset {
-            
+            subTypes {
+              typeNames
+            }
             name
+            urn
+            
           }
         }
       }

--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -954,6 +954,19 @@ fragment entityPreview on Entity {
       name
       description
     }
+    entities(input: {
+      start: 0
+    query: "*"}) {
+      searchResults {
+        entity {
+          urn
+          ... on Dataset {
+            
+            name
+          }
+        }
+      }
+    }    
     structuredProperties {
       properties {
         ...structuredPropertiesFields

--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -795,6 +795,11 @@ fragment entityPreview on Entity {
         value
       }
     }
+    structuredProperties {
+      properties {
+        ...structuredPropertiesFields
+      }
+    }
     deprecation {
       ...deprecationFields
     }
@@ -803,6 +808,11 @@ fragment entityPreview on Entity {
     properties {
       name
       description
+    }
+    structuredProperties {
+      properties {
+        ...structuredPropertiesFields
+      }
     }
   }
   ... on MLFeatureTable {
@@ -943,6 +953,11 @@ fragment entityPreview on Entity {
     properties {
       name
       description
+    }
+    structuredProperties {
+      properties {
+        ...structuredPropertiesFields
+      }
     }
   }
   ... on Container {

--- a/src/mcp_server_datahub/gql/search.gql
+++ b/src/mcp_server_datahub/gql/search.gql
@@ -1,6 +1,25 @@
 fragment SearchEntityInfo on Entity {
   urn
-
+  ... on StructuredPropertyEntity {
+    definition {
+      displayName
+      qualifiedName
+      description
+      allowedValues {
+        value {
+          ... on StringValue {
+            stringValue
+          }
+          ... on NumberValue {
+            numberValue
+          }
+        }
+        description
+      }
+      cardinality
+    }
+  }
+      
   # For some entity types, the urns are not human-readable. For those,
   # we pull the name as well.
   ... on Dataset {


### PR DESCRIPTION
Adds the schema fields that we wish get_entity to get in the graphql - plain right now for MVP - will do fragments later