### PR TITLE
feat: add `Dockerfile` to use container as stdio mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY README.md .
+COPY src ./src
+
+RUN pip install --upgrade pip && pip install uv && uv sync
+
+ENV TRANSPORT="stdio"
+
+EXPOSE 8000
+
+CMD [ "sh", "-c", "uv run mcp-server-datahub --transport ${TRANSPORT}" ]


### PR DESCRIPTION
Added Dockerfile to run MCP using docker.

```sh
docker build -t mcp-server-datahub:latest .
```

The image can be used by setup mcp.json like this:
```json
{
  "servers": {
    "datahub": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "-e",
        "DATAHUB_GMS_URL",
        "-e",
        "DATAHUB_GMS_TOKEN",
        "datahub-mcp-server:latest"
      ],
      "env": {
        "DATAHUB_GMS_URL": "http://localhost:8080",
        "DATAHUB_GMS_TOKEN": ""
      }
    }
  }
}
```


`sse` or `http` mode may be available after https://github.com/acryldata/mcp-server-datahub/pull/29 merged.
```sh
docker run --rm \
-e DATAHUB_GMS_URL="http://localhost:8080" -e DATAHUB_GMS_TOKEN="" \
-e TRANSPORT=sse
datahub-mcp-server:latest
```