### PR TITLE
add readOnlyHint to read tools in mcp

### DIFF
--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -141,7 +141,6 @@ def _register_tool(
     *,
     description: Optional[str] = None,
     tags: Optional[set] = None,
-    annotations: Optional[dict] = None,
 ) -> None:
     """Register a tool on the MCP instance and capture its version requirement.
 
@@ -150,6 +149,8 @@ def _register_tool(
     2. Registers it on the MCP instance
     3. Reads the _version_requirement attribute (set by @min_version decorator)
        and populates TOOL_VERSION_REQUIREMENTS
+    4. Reads the _read_only_hint attribute (set by @read_only decorator)
+       and sets readOnlyHint=True in the tool's MCP annotations
 
     Args:
         mcp_instance: The FastMCP instance to register on.
@@ -157,10 +158,11 @@ def _register_tool(
         fn: The tool function (sync).
         description: Tool description. Defaults to fn.__doc__.
         tags: Optional set of tag strings.
-        annotations: Optional MCP tool annotations dict (e.g. {"readOnlyHint": True}).
-            readOnlyHint=True signals to MCP clients (e.g. Cursor BugBot, VS Code Copilot)
-            that the tool does not modify state and is safe to call autonomously.
     """
+    annotations: Optional[dict] = None
+    if getattr(fn, "_read_only_hint", False):
+        annotations = {"readOnlyHint": True}
+
     mcp_instance.tool(
         name=name,
         description=description or fn.__doc__,
@@ -317,7 +319,7 @@ def register_user_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
     if not enabled:
         return
 
-    _register_tool(mcp_instance, "get_me", get_me, tags={ToolType.USER.value}, annotations={"readOnlyHint": True})
+    _register_tool(mcp_instance, "get_me", get_me, tags={ToolType.USER.value})
 
 
 def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
@@ -368,7 +370,7 @@ def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
         # This allows the tool to be registered even if validation would fail,
         # but provides clear error messages when semantic search is actually attempted
         _register_tool(
-            mcp_instance, "search", enhanced_search, tags={ToolType.SEARCH.value}, annotations={"readOnlyHint": True}
+            mcp_instance, "search", enhanced_search, tags={ToolType.SEARCH.value}
         )
     else:
         # Register original search tool with deployment-specific description
@@ -378,38 +380,34 @@ def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
             search,
             description=search_description,
             tags={ToolType.SEARCH.value},
-            annotations={"readOnlyHint": True},
         )
 
     _register_tool(
-        mcp_instance, "get_lineage", get_lineage, tags={ToolType.SEARCH.value}, annotations={"readOnlyHint": True}
+        mcp_instance, "get_lineage", get_lineage, tags={ToolType.SEARCH.value}
     )
     _register_tool(
         mcp_instance,
         "get_dataset_queries",
         get_dataset_queries,
         tags={ToolType.SEARCH.value},
-        annotations={"readOnlyHint": True},
     )
     _register_tool(
-        mcp_instance, "get_entities", get_entities, tags={ToolType.SEARCH.value}, annotations={"readOnlyHint": True}
+        mcp_instance, "get_entities", get_entities, tags={ToolType.SEARCH.value}
     )
     _register_tool(
         mcp_instance,
         "list_schema_fields",
         list_schema_fields,
         tags={ToolType.SEARCH.value},
-        annotations={"readOnlyHint": True},
     )
     _register_tool(
         mcp_instance,
         "get_lineage_paths_between",
         get_lineage_paths_between,
         tags={ToolType.SEARCH.value},
-        annotations={"readOnlyHint": True},
     )
-    _register_tool(mcp_instance, "search_documents", search_documents, annotations={"readOnlyHint": True})
-    _register_tool(mcp_instance, "grep_documents", grep_documents, annotations={"readOnlyHint": True})
+    _register_tool(mcp_instance, "search_documents", search_documents)
+    _register_tool(mcp_instance, "grep_documents", grep_documents)
 
 
 def register_data_quality_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
@@ -435,7 +433,6 @@ def register_data_quality_tools(mcp_instance: FastMCP, is_oss: bool = False) -> 
         "get_dataset_assertions",
         get_dataset_assertions,
         tags={ToolType.SEARCH.value},
-        annotations={"readOnlyHint": True},
     )
 
 

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -141,6 +141,7 @@ def _register_tool(
     *,
     description: Optional[str] = None,
     tags: Optional[set] = None,
+    annotations: Optional[dict] = None,
 ) -> None:
     """Register a tool on the MCP instance and capture its version requirement.
 
@@ -156,11 +157,15 @@ def _register_tool(
         fn: The tool function (sync).
         description: Tool description. Defaults to fn.__doc__.
         tags: Optional set of tag strings.
+        annotations: Optional MCP tool annotations dict (e.g. {"readOnlyHint": True}).
+            readOnlyHint=True signals to MCP clients (e.g. Cursor BugBot, VS Code Copilot)
+            that the tool does not modify state and is safe to call autonomously.
     """
     mcp_instance.tool(
         name=name,
         description=description or fn.__doc__,
         tags=tags,
+        annotations=annotations,
     )(async_background(fn))
 
     req = getattr(fn, "_version_requirement", None)
@@ -312,7 +317,7 @@ def register_user_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
     if not enabled:
         return
 
-    _register_tool(mcp_instance, "get_me", get_me, tags={ToolType.USER.value})
+    _register_tool(mcp_instance, "get_me", get_me, tags={ToolType.USER.value}, annotations={"readOnlyHint": True})
 
 
 def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
@@ -363,7 +368,7 @@ def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
         # This allows the tool to be registered even if validation would fail,
         # but provides clear error messages when semantic search is actually attempted
         _register_tool(
-            mcp_instance, "search", enhanced_search, tags={ToolType.SEARCH.value}
+            mcp_instance, "search", enhanced_search, tags={ToolType.SEARCH.value}, annotations={"readOnlyHint": True}
         )
     else:
         # Register original search tool with deployment-specific description
@@ -373,34 +378,38 @@ def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
             search,
             description=search_description,
             tags={ToolType.SEARCH.value},
+            annotations={"readOnlyHint": True},
         )
 
     _register_tool(
-        mcp_instance, "get_lineage", get_lineage, tags={ToolType.SEARCH.value}
+        mcp_instance, "get_lineage", get_lineage, tags={ToolType.SEARCH.value}, annotations={"readOnlyHint": True}
     )
     _register_tool(
         mcp_instance,
         "get_dataset_queries",
         get_dataset_queries,
         tags={ToolType.SEARCH.value},
+        annotations={"readOnlyHint": True},
     )
     _register_tool(
-        mcp_instance, "get_entities", get_entities, tags={ToolType.SEARCH.value}
+        mcp_instance, "get_entities", get_entities, tags={ToolType.SEARCH.value}, annotations={"readOnlyHint": True}
     )
     _register_tool(
         mcp_instance,
         "list_schema_fields",
         list_schema_fields,
         tags={ToolType.SEARCH.value},
+        annotations={"readOnlyHint": True},
     )
     _register_tool(
         mcp_instance,
         "get_lineage_paths_between",
         get_lineage_paths_between,
         tags={ToolType.SEARCH.value},
+        annotations={"readOnlyHint": True},
     )
-    _register_tool(mcp_instance, "search_documents", search_documents)
-    _register_tool(mcp_instance, "grep_documents", grep_documents)
+    _register_tool(mcp_instance, "search_documents", search_documents, annotations={"readOnlyHint": True})
+    _register_tool(mcp_instance, "grep_documents", grep_documents, annotations={"readOnlyHint": True})
 
 
 def register_data_quality_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
@@ -426,6 +435,7 @@ def register_data_quality_tools(mcp_instance: FastMCP, is_oss: bool = False) -> 
         "get_dataset_assertions",
         get_dataset_assertions,
         tags={ToolType.SEARCH.value},
+        annotations={"readOnlyHint": True},
     )
 
 

--- a/src/mcp_server_datahub/tools/assertions.py
+++ b/src/mcp_server_datahub/tools/assertions.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Literal, Optional
 
 from .. import graphql_helpers
-from ..version_requirements import min_version
+from ..version_requirements import min_version, read_only
 
 logger = logging.getLogger(__name__)
 
@@ -341,6 +341,7 @@ def _extract_tags(assertion: dict[str, Any]) -> list[str]:
     return result
 
 
+@read_only
 @min_version(cloud="0.3.16")
 def get_dataset_assertions(
     urn: str,

--- a/src/mcp_server_datahub/tools/dataset_queries.py
+++ b/src/mcp_server_datahub/tools/dataset_queries.py
@@ -8,6 +8,7 @@ from datahub.sdk.search_filters import FilterDsl
 from datahub.utilities.ordered_set import OrderedSet
 
 from .. import graphql_helpers
+from ..version_requirements import read_only
 
 queries_gql = (graphql_helpers.GQL_DIR / "queries.gql").read_text()
 
@@ -24,6 +25,7 @@ def _deduplicate_subjects(subjects: list[dict]) -> list[str]:
     return list(updated_subjects)
 
 
+@read_only
 def get_dataset_queries(
     urn: str,
     column: Optional[str] = None,

--- a/src/mcp_server_datahub/tools/documents.py
+++ b/src/mcp_server_datahub/tools/documents.py
@@ -8,7 +8,7 @@ from datahub.utilities.perf_timer import PerfTimer
 from loguru import logger
 
 from .. import graphql_helpers
-from ..version_requirements import min_version
+from ..version_requirements import min_version, read_only
 
 # Load GraphQL queries at module level (no circular dependency here)
 document_search_gql = (
@@ -265,6 +265,7 @@ def _hybrid_search_documents(
     return graphql_helpers.clean_gql_response(merged)
 
 
+@read_only
 @min_version(cloud="0.3.16", oss="1.4.0")
 def search_documents(
     query: str = "*",
@@ -477,6 +478,7 @@ def _search_documents_impl(
     return graphql_helpers.clean_gql_response(response)
 
 
+@read_only
 @min_version(cloud="0.3.16", oss="1.4.0")
 def grep_documents(
     urns: List[str],

--- a/src/mcp_server_datahub/tools/entities.py
+++ b/src/mcp_server_datahub/tools/entities.py
@@ -8,6 +8,7 @@ from json_repair import repair_json
 from loguru import logger
 
 from .. import graphql_helpers
+from ..version_requirements import read_only
 
 entity_details_fragment_gql = (
     graphql_helpers.GQL_DIR / "entity_details.gql"
@@ -16,6 +17,7 @@ query_entity_gql = (graphql_helpers.GQL_DIR / "query_entity.gql").read_text()
 related_documents_gql = (graphql_helpers.GQL_DIR / "related_documents.gql").read_text()
 
 
+@read_only
 def get_entities(urns: List[str] | str) -> List[dict] | dict:
     """Get detailed information about one or more entities by their DataHub URNs.
 
@@ -134,6 +136,7 @@ def get_entities(urns: List[str] | str) -> List[dict] | dict:
     return results[0] if return_single else results
 
 
+@read_only
 def list_schema_fields(
     urn: str,
     keywords: Optional[List[str]] = None,

--- a/src/mcp_server_datahub/tools/get_me.py
+++ b/src/mcp_server_datahub/tools/get_me.py
@@ -4,11 +4,12 @@ import logging
 from typing import Any
 
 from .. import graphql_helpers
-from ..version_requirements import min_version
+from ..version_requirements import min_version, read_only
 
 logger = logging.getLogger(__name__)
 
 
+@read_only
 @min_version(cloud="0.3.16", oss="1.4.0")
 def get_me() -> dict[str, Any]:
     """Get information about the currently authenticated user.

--- a/src/mcp_server_datahub/tools/lineage.py
+++ b/src/mcp_server_datahub/tools/lineage.py
@@ -11,6 +11,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from .. import graphql_helpers
+from ..version_requirements import read_only
 
 entity_details_fragment_gql = (
     graphql_helpers.GQL_DIR / "entity_details.gql"
@@ -213,6 +214,7 @@ def _extract_lineage_columns_from_paths(search_results: List[dict]) -> List[dict
 
 # TODO: Consider adding sorting support (sort_by, sort_order parameters) similar to search() tool.
 # GraphQL SearchAcrossLineageInput supports sortInput parameter.
+@read_only
 def get_lineage(
     urn: str,
     column: Optional[str] = None,
@@ -593,6 +595,7 @@ def _find_lineage_path(
         )
 
 
+@read_only
 def get_lineage_paths_between(
     source_urn: str,
     target_urn: str,

--- a/src/mcp_server_datahub/tools/search.py
+++ b/src/mcp_server_datahub/tools/search.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from .. import graphql_helpers
 from ..search_filter_parser import FILTER_DOCS
+from ..version_requirements import read_only
 
 search_gql = (graphql_helpers.GQL_DIR / "search.gql").read_text()
 semantic_search_gql = (graphql_helpers.GQL_DIR / "semantic_search.gql").read_text()
@@ -95,6 +96,7 @@ def _search_implementation(
 
 # Define enhanced search tool when semantic search is enabled
 # TODO: Consider adding sorting support (sort_by, sort_order parameters) similar to search() tool if needed.
+@read_only
 def enhanced_search(
     query: str = "*",
     search_strategy: Optional[Literal["semantic", "keyword"]] = None,
@@ -182,6 +184,7 @@ enhanced_search.__doc__ = string.Template(enhanced_search.__doc__).substitute(
 )
 
 
+@read_only
 def search(
     query: str = "*",
     filter: Optional[str] = None,

--- a/src/mcp_server_datahub/version_requirements.py
+++ b/src/mcp_server_datahub/version_requirements.py
@@ -109,6 +109,13 @@ def min_version(
     )
 
     def decorator(fn: Callable) -> Callable:
+        # NOTE: We intentionally mutate fn in place rather than wrapping with
+        # functools.wraps.  These decorators are stacked (e.g. @read_only over
+        # @min_version), and each sets a custom attribute (_version_requirement,
+        # _read_only_hint) that _register_tool reads at registration time.
+        # Wrapping would create a new function object, hiding attributes set by
+        # inner decorators and silently breaking version filtering or annotation
+        # propagation.
         fn._version_requirement = req  # type: ignore[attr-defined]
         return fn
 
@@ -131,6 +138,8 @@ def read_only(fn: Callable) -> Callable:
         def my_tool(...):
             ...
     """
+    # NOTE: Mutates fn in place — do NOT wrap with functools.wraps.
+    # See comment in min_version() for rationale.
     fn._read_only_hint = True  # type: ignore[attr-defined]
     return fn
 

--- a/src/mcp_server_datahub/version_requirements.py
+++ b/src/mcp_server_datahub/version_requirements.py
@@ -115,6 +115,26 @@ def min_version(
     return decorator
 
 
+def read_only(fn: Callable) -> Callable:
+    """Decorator to declare that a tool does not modify any state.
+
+    Signals to MCP clients (e.g. Cursor BugBot, VS Code Copilot) that the tool
+    is safe to call autonomously without risk of side effects. Corresponds to
+    the MCP protocol's ``readOnlyHint`` annotation.
+
+    During tool registration, ``_register_tool`` reads this attribute and
+    sets ``readOnlyHint=True`` in the tool's MCP annotations automatically.
+
+    Usage::
+
+        @read_only
+        def my_tool(...):
+            ...
+    """
+    fn._read_only_hint = True  # type: ignore[attr-defined]
+    return fn
+
+
 # Auto-populated during tool registration by _register_tool().
 # Maps tool name -> VersionRequirement. Tools not in this dict have no version restriction.
 TOOL_VERSION_REQUIREMENTS: dict[str, VersionRequirement] = {}

--- a/tests/test_mcp/test_read_only.py
+++ b/tests/test_mcp/test_read_only.py
@@ -1,0 +1,91 @@
+"""
+Tests for the @read_only decorator and its integration with _register_tool.
+
+Test scenarios:
+1. @read_only sets _read_only_hint = True on the decorated function
+2. Undecorated functions do not have _read_only_hint
+3. @read_only preserves function identity (name, docstring, return value)
+4. _register_tool passes readOnlyHint=True in annotations for @read_only functions
+5. _register_tool passes no annotations for undecorated functions
+"""
+
+from unittest.mock import MagicMock, patch
+
+from datahub_integrations.mcp.version_requirements import read_only
+from datahub_integrations.mcp.mcp_server import _register_tool
+
+
+class TestReadOnlyDecorator:
+    """Tests for the @read_only decorator."""
+
+    def test_sets_read_only_hint_attribute(self):
+        @read_only
+        def my_tool():
+            pass
+
+        assert hasattr(my_tool, "_read_only_hint")
+        assert my_tool._read_only_hint is True
+
+    def test_undecorated_function_has_no_attribute(self):
+        def my_tool():
+            pass
+
+        assert not hasattr(my_tool, "_read_only_hint")
+
+    def test_preserves_function_identity(self):
+        @read_only
+        def my_tool():
+            """My docstring."""
+            return 42
+
+        assert my_tool() == 42
+        assert my_tool.__doc__ == "My docstring."
+        assert my_tool.__name__ == "my_tool"
+
+    def test_composable_with_min_version(self):
+        from datahub_integrations.mcp.version_requirements import min_version
+
+        @read_only
+        @min_version(cloud="0.3.16", oss="1.4.0")
+        def my_tool():
+            pass
+
+        assert my_tool._read_only_hint is True
+        assert hasattr(my_tool, "_version_requirement")
+
+
+class TestRegisterToolAnnotations:
+    """Tests that _register_tool correctly converts _read_only_hint to readOnlyHint."""
+
+    def _make_mock_mcp(self):
+        """Return a mock FastMCP instance that captures tool() call kwargs."""
+        mock_mcp = MagicMock()
+        mock_mcp.tool.return_value = lambda fn: fn
+        return mock_mcp
+
+    def test_read_only_function_gets_readonly_annotation(self):
+        @read_only
+        def my_tool():
+            """A read-only tool."""
+
+        mock_mcp = self._make_mock_mcp()
+
+        with patch("datahub_integrations.mcp.mcp_server.async_background", side_effect=lambda fn: fn):
+            _register_tool(mock_mcp, "my_tool", my_tool)
+
+        mock_mcp.tool.assert_called_once()
+        _, kwargs = mock_mcp.tool.call_args
+        assert kwargs.get("annotations") == {"readOnlyHint": True}
+
+    def test_undecorated_function_has_no_annotations(self):
+        def my_tool():
+            """A plain tool."""
+
+        mock_mcp = self._make_mock_mcp()
+
+        with patch("datahub_integrations.mcp.mcp_server.async_background", side_effect=lambda fn: fn):
+            _register_tool(mock_mcp, "my_tool", my_tool)
+
+        mock_mcp.tool.assert_called_once()
+        _, kwargs = mock_mcp.tool.call_args
+        assert kwargs.get("annotations") is None

--- a/tests/test_mcp/test_read_only.py
+++ b/tests/test_mcp/test_read_only.py
@@ -70,7 +70,10 @@ class TestRegisterToolAnnotations:
 
         mock_mcp = self._make_mock_mcp()
 
-        with patch("datahub_integrations.mcp.mcp_server.async_background", side_effect=lambda fn: fn):
+        with patch(
+            "datahub_integrations.mcp.mcp_server.async_background",
+            side_effect=lambda fn: fn,
+        ):
             _register_tool(mock_mcp, "my_tool", my_tool)
 
         mock_mcp.tool.assert_called_once()
@@ -83,7 +86,10 @@ class TestRegisterToolAnnotations:
 
         mock_mcp = self._make_mock_mcp()
 
-        with patch("datahub_integrations.mcp.mcp_server.async_background", side_effect=lambda fn: fn):
+        with patch(
+            "datahub_integrations.mcp.mcp_server.async_background",
+            side_effect=lambda fn: fn,
+        ):
             _register_tool(mock_mcp, "my_tool", my_tool)
 
         mock_mcp.tool.assert_called_once()


### PR DESCRIPTION
I'm trying to integrate the DataHub MCP with Cursor BugBot, but BugBot's dashboard mentions

>Give Bugbot access to MCP servers for additional context during code reviews. Only read-only annotated tools are exposed.

This change adds a `readOnlyHint` to the DataHub MCP tools that are safe to call without changing underlying data. I found this config value from [this blog post](https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/).