### PR TITLE
Exclude fakeredis 2.35.0 to fix startup crash/hang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "acryl-datahub>=1.3.1.7",
     "asyncer>=0.0.8",
     "cachetools>=5.0.0",
+    "fakeredis!=2.35.0",
     "fastmcp>=2.14.5,<3",
     "jmespath~=1.0.1",
     "loguru",


### PR DESCRIPTION
## Summary
- Excludes `fakeredis==2.35.0` which renamed `FakeConnection` to `FakeAsyncRedisConnection`, breaking `pydocket 0.18.2` (a transitive dep via `fastmcp`)
- This caused all 0.5.x releases to crash with `ImportError` or hang indefinitely on startup
- Once `fakeredis 2.35.1` is released with the upstream fix (cunla/fakeredis-py#468), it will be automatically allowed

Fixes #108

## Test plan
- [ ] Verify `uvx mcp-server-datahub` starts successfully with stdio transport
- [ ] Confirm `fakeredis!=2.35.0` constraint resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)