### PR TITLE
fix: add ERModelRelationship GraphQL fragments and document source/destination filters    

### DIFF
--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -1226,6 +1226,24 @@ fragment entityPreview on Entity {
             }
         }
     }
+    ... on ERModelRelationship {
+        urn
+        type
+        properties {
+            name
+            source {
+                urn
+            }
+            destination {
+                urn
+            }
+            relationshipFieldMappings {
+                sourceField
+                destinationField
+            }
+            cardinality
+        }
+    }
     ... on Incident {
         urn
         type

--- a/src/mcp_server_datahub/gql/search.gql
+++ b/src/mcp_server_datahub/gql/search.gql
@@ -52,6 +52,11 @@ fragment SearchEntityInfo on Entity {
       name
     }
   }
+  ... on ERModelRelationship {
+    properties {
+      name
+    }
+  }
 }
 
 fragment FacetEntityInfo on Entity {

--- a/src/mcp_server_datahub/search_filter_parser.py
+++ b/src/mcp_server_datahub/search_filter_parser.py
@@ -110,6 +110,10 @@ FILTER SYNTAX (SQL-like WHERE clause):
     - hasActiveIncidents: true or false (whether the entity has active incidents)
     - hasFailingAssertions: true or false (whether the entity has failing assertions)
     - columnCount: number of columns (from dataset profiling)
+    - source: dataset URN that is the FK (source) side of an ER model relationship
+    - destination: dataset URN that is the PK (destination) side of an ER model relationship
+      (use either or both together to find all ERModelRelationship entities touching a dataset,
+      e.g. entity_type = erModelRelationship AND source = "urn:li:dataset:(...)")
 
     IMPORTANT: Domain, container, tag, glossary_term, and owner filters require
     full URN format (urn:li:...). Search with entity_type = domain first to find
@@ -125,7 +129,7 @@ FILTER SYNTAX (SQL-like WHERE clause):
     (e.g. "Published", "Certified"). Use get_entities on the structured property URN
     to check definition.allowedValues and match the exact casing.
 
-    Values containing special characters (spaces, =, parentheses) must be quoted:
+    Values containing special characters (spaces, =, parentheses, commas) must be quoted:
       tag = "urn:li:tag:my tag"
       customProperties = "key=value"\
 """

--- a/tests/test_mcp/test_get_entities.py
+++ b/tests/test_mcp/test_get_entities.py
@@ -622,3 +622,50 @@ class TestGetEntitiesRelatedDocuments:
                     == "Table2 Doc"
                 )
                 assert mock_gql.call_count == 4
+
+
+class TestGetEntitiesERModelRelationship:
+    """Tests for get_entities with ERModelRelationship URNs."""
+
+    async def test_er_model_relationship_properties_returned(self, mock_client):
+        """Properties from the ERModelRelationship fragment are passed through unchanged."""
+        urn = "urn:li:erModelRelationship:abc123"
+        er_model_response = {
+            "urn": urn,
+            "type": "ER_MODEL_RELATIONSHIP",
+            "properties": {
+                "name": "orders_to_customers",
+                "source": {"urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,Orders,PROD)"},
+                "destination": {"urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,Customers,PROD)"},
+                "relationshipFieldMappings": [
+                    {"sourceField": "customer_id", "destinationField": "id"}
+                ],
+                "cardinality": "MANY_TO_ONE",
+            },
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_client,
+        ):
+            mock_client._graph.exists.return_value = True
+
+            with patch(
+                "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+            ) as mock_gql:
+                mock_gql.side_effect = [
+                    {"entity": er_model_response},
+                    {"entity": {}},  # related documents call
+                ]
+
+                from datahub_integrations.mcp.mcp_server import get_entities
+
+                result = await async_background(get_entities)(urn)
+
+        assert result["urn"] == urn
+        props = result["properties"]
+        assert props["name"] == "orders_to_customers"
+        assert props["source"]["urn"] == "urn:li:dataset:(urn:li:dataPlatform:mssql,Orders,PROD)"
+        assert props["destination"]["urn"] == "urn:li:dataset:(urn:li:dataPlatform:mssql,Customers,PROD)"
+        assert props["relationshipFieldMappings"][0]["sourceField"] == "customer_id"
+        assert props["cardinality"] == "MANY_TO_ONE"

--- a/tests/test_mcp/test_get_entities.py
+++ b/tests/test_mcp/test_get_entities.py
@@ -635,8 +635,12 @@ class TestGetEntitiesERModelRelationship:
             "type": "ER_MODEL_RELATIONSHIP",
             "properties": {
                 "name": "orders_to_customers",
-                "source": {"urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,Orders,PROD)"},
-                "destination": {"urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,Customers,PROD)"},
+                "source": {
+                    "urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,Orders,PROD)"
+                },
+                "destination": {
+                    "urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,Customers,PROD)"
+                },
                 "relationshipFieldMappings": [
                     {"sourceField": "customer_id", "destinationField": "id"}
                 ],
@@ -665,7 +669,13 @@ class TestGetEntitiesERModelRelationship:
         assert result["urn"] == urn
         props = result["properties"]
         assert props["name"] == "orders_to_customers"
-        assert props["source"]["urn"] == "urn:li:dataset:(urn:li:dataPlatform:mssql,Orders,PROD)"
-        assert props["destination"]["urn"] == "urn:li:dataset:(urn:li:dataPlatform:mssql,Customers,PROD)"
+        assert (
+            props["source"]["urn"]
+            == "urn:li:dataset:(urn:li:dataPlatform:mssql,Orders,PROD)"
+        )
+        assert (
+            props["destination"]["urn"]
+            == "urn:li:dataset:(urn:li:dataPlatform:mssql,Customers,PROD)"
+        )
         assert props["relationshipFieldMappings"][0]["sourceField"] == "customer_id"
         assert props["cardinality"] == "MANY_TO_ONE"


### PR DESCRIPTION
## Summary

- Adds `... on ERModelRelationship { properties { ... } }` to the `entityPreview` fragment in `entity_details.gql` (used by `GetEntity`), requesting `name`, `source`, `destination`, `relationshipFieldMappings`, and `cardinality`
- Adds the same fragment to `SearchEntityInfo` in `search.gql` (used by `searchAcrossEntities`) so search results also return the relationship name
- Documents `source` and `destination` as valid filter fields in `FILTER_DOCS`; values containing parentheses must be quoted per the existing contract: `source = "urn:li:dataset:(urn:li:dataPlatform:mssql,MyTable,PROD)"`

Fixes  #118 

## Test Plan

- [x] `TestGetEntitiesERModelRelationship::test_er_model_relationship_properties_returned` — mocks a full ERModelRelationship GQL response and asserts all properties flow through `get_entities` unchanged
- [x] Full unit test suite (502 tests) passes with no regressions
- [x] Manual verification against a live DataHub instance with `erModelRelationship` entities ingested