### PR TITLE
Add custom properties to DataFlow and DataJob entity preview

### DIFF
--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -715,6 +715,10 @@ fragment entityPreview on Entity {
             name
             description
             project
+            customProperties {
+                key
+                value
+            }
         }
         ownership {
             ...ownershipFields
@@ -760,6 +764,10 @@ fragment entityPreview on Entity {
         properties {
             name
             description
+            customProperties {
+                key
+                value
+            }
         }
         tags {
             ...globalTagsFields


### PR DESCRIPTION
Extends the entityPreview GraphQL fragment to include customProperties (key-value pairs) for DataFlow and DataJob entities. Previously these fields were omitted, so custom metadata attached to pipeline entities was not returned by the server.