### PR TITLE
fix(tools): sync mcp server changes

### DIFF
--- a/src/mcp_server_datahub/gql/queries.gql
+++ b/src/mcp_server_datahub/gql/queries.gql
@@ -29,7 +29,10 @@ fragment query on QueryEntity {
   subjects {
     dataset {
       urn
-      name
+      type
+      ... on Dataset {
+        name
+      }
     }
     schemaField {
       urn

--- a/src/mcp_server_datahub/gql/query_entity.gql
+++ b/src/mcp_server_datahub/gql/query_entity.gql
@@ -23,7 +23,10 @@ query GetQueryEntity($urn: String!) {
       subjects {
         dataset {
           urn
-          name
+          type
+          ... on Dataset {
+            name
+          }
         }
         schemaField {
           urn

--- a/src/mcp_server_datahub/graphql_helpers.py
+++ b/src/mcp_server_datahub/graphql_helpers.py
@@ -41,7 +41,7 @@ from .tool_context import ToolContext
 GQL_DIR = pathlib.Path(__file__).parent / "gql"
 
 T = TypeVar("T")
-DESCRIPTION_LENGTH_HARD_LIMIT = 1000
+DESCRIPTION_LENGTH_HARD_LIMIT = int(os.getenv("DESCRIPTION_LENGTH_LIMIT", "5000"))
 QUERY_LENGTH_HARD_LIMIT = 5000
 DOCUMENT_CONTENT_CHAR_LIMIT = 8000
 
@@ -209,10 +209,10 @@ def truncate_descriptions(
             if key == "description" and isinstance(value, str):
                 data[key] = sanitize_and_truncate_description(value, max_length)
             elif isinstance(value, (dict, list)):
-                truncate_descriptions(value)
+                truncate_descriptions(value, max_length)
     elif isinstance(data, list):
         for item in data:
-            truncate_descriptions(item)
+            truncate_descriptions(item, max_length)
 
 
 def truncate_query(query: str) -> str:
@@ -264,7 +264,10 @@ def set_datahub_client(
     tool_context: ToolContext | None = None,
 ) -> None:
     _mcp_context.set(
-        MCPContext(client=client, tool_context=tool_context or ToolContext())
+        MCPContext(
+            client=client,
+            tool_context=tool_context or ToolContext(),
+        )
     )
 
 
@@ -273,7 +276,10 @@ def with_datahub_client(
     client: DataHubClient,
     tool_context: ToolContext | None = None,
 ) -> Iterator[None]:
-    ctx = MCPContext(client=client, tool_context=tool_context or ToolContext())
+    ctx = MCPContext(
+        client=client,
+        tool_context=tool_context or ToolContext(),
+    )
     token = _mcp_context.set(ctx)
     try:
         yield

--- a/src/mcp_server_datahub/tools/documents.py
+++ b/src/mcp_server_datahub/tools/documents.py
@@ -416,8 +416,15 @@ def _search_documents_impl(
     filter: Optional[str] = None,
     num_results: int = 10,
     offset: int = 0,
+    max_num_results: int = 50,
 ) -> dict:
-    """Internal implementation for document search with keyword or semantic strategy."""
+    """Internal implementation for document search with keyword or semantic strategy.
+
+    ``max_num_results`` caps ``num_results`` before the request is issued. The
+    public :func:`search_documents` tool passes the default (50) to honor its
+    advertised per-page limit, while internal callers (e.g. hybrid search and
+    rerank-aware overrides) raise it to widen the candidate pool.
+    """
     from datahub.sdk.search_client import compile_filters
 
     from ..search_filter_parser import parse_filter_string
@@ -425,8 +432,7 @@ def _search_documents_impl(
 
     client = graphql_helpers.get_datahub_client()
 
-    # Cap num_results at 50
-    num_results = min(num_results, 50)
+    num_results = min(num_results, max_num_results)
 
     # Parse SQL-like filter string and compile to orFilters
     parsed_filter = parse_filter_string(filter.strip()) if filter else None

--- a/src/mcp_server_datahub/tools/owners.py
+++ b/src/mcp_server_datahub/tools/owners.py
@@ -2,7 +2,7 @@
 
 import logging
 from enum import Enum
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from datahub.sdk.main_client import DataHubClient
 
@@ -10,6 +10,8 @@ from .. import graphql_helpers
 from ..version_requirements import min_version
 
 logger = logging.getLogger(__name__)
+
+OWNERSHIP_TYPE_URN_PREFIX = "urn:li:ownershipType:"
 
 
 class OwnershipType(str, Enum):
@@ -21,7 +23,105 @@ class OwnershipType(str, Enum):
 
     def to_urn(self) -> str:
         """Convert the ownership type to its URN form."""
-        return f"urn:li:ownershipType:{self.value}"
+        return f"{OWNERSHIP_TYPE_URN_PREFIX}{self.value}"
+
+
+OwnershipTypeInput = Union[OwnershipType, str]
+
+
+def _resolve_ownership_type_urn(
+    client: DataHubClient, ownership_type: OwnershipTypeInput
+) -> str:
+    """Convert an OwnershipType enum or custom ownership-type name to a validated URN.
+
+    Built-in OwnershipType enums are trusted and returned directly. Custom inputs are
+    resolved by name (case-insensitive) via `listOwnershipTypes` — this matches what a
+    user sees in the UI, rather than requiring them to know the underlying URN.
+    """
+    if isinstance(ownership_type, OwnershipType):
+        return ownership_type.to_urn()
+
+    if not isinstance(ownership_type, str) or not ownership_type.strip():
+        raise ValueError(
+            "ownership_type must be an OwnershipType or a non-empty string"
+        )
+
+    candidate = ownership_type.strip()
+
+    # Fast-path: built-in passed as a string, either by enum name
+    # ("TECHNICAL_OWNER") or enum value ("__system__technical_owner").
+    # Avoids a GraphQL round-trip and makes the previously-accidental
+    # enum-value-as-string case intentional.
+    if candidate in OwnershipType.__members__:
+        return OwnershipType[candidate].to_urn()
+    if candidate in OwnershipType._value2member_map_:
+        return OwnershipType(candidate).to_urn()
+
+    # Fast-path: caller already passed a fully-qualified ownership type URN
+    # (e.g. "urn:li:ownershipType:__system__technical_owner" or a custom URN).
+    # Trust it as-is rather than treating it as a name to look up.
+    if candidate.startswith(OWNERSHIP_TYPE_URN_PREFIX):
+        return candidate
+
+    # We look up by name rather than by URN because the URN is an opaque internal
+    # identifier (often a generated id like `urn:li:ownershipType:abc-123`) that
+    # users/LLMs don't know. The name is what's shown in the UI and what callers
+    # would naturally reference, so we resolve name -> URN via listOwnershipTypes.
+    query = """
+        query listOwnershipTypes($input: ListOwnershipTypesInput!) {
+            listOwnershipTypes(input: $input) {
+                ownershipTypes {
+                    urn
+                    info {
+                        name
+                    }
+                }
+            }
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=query,
+            variables={"input": {"start": 0, "count": 1000, "query": candidate}},
+            operation_name="listOwnershipTypes",
+        )
+    except Exception as e:
+        raise ValueError(
+            f"Failed to look up ownership type '{ownership_type}': {str(e)}"
+        ) from e
+
+    ownership_types = (result.get("listOwnershipTypes") or {}).get(
+        "ownershipTypes"
+    ) or []
+
+    # listOwnershipTypes returns partial/prefix matches — filter for an exact name
+    # match (case-insensitive) since name is the user-facing identifier.
+    matches = [
+        ot
+        for ot in ownership_types
+        if ((ot.get("info") or {}).get("name") or "").strip().lower()
+        == candidate.lower()
+    ]
+
+    if not matches:
+        raise ValueError(
+            f"Ownership type with name '{ownership_type}' was not found in DataHub. "
+            f"Use one of the built-in OwnershipType values or create the custom ownership type first."
+        )
+    if len(matches) > 1:
+        found_urns = ", ".join(m.get("urn", "<unknown>") for m in matches)
+        raise ValueError(
+            f"Ownership type name '{ownership_type}' is ambiguous — matched multiple entries: {found_urns}."
+        )
+
+    urn = matches[0].get("urn")
+    if not urn:
+        raise ValueError(
+            f"Ownership type '{ownership_type}' was found but is missing a URN."
+        )
+    return urn
 
 
 def _validate_owner_urns(client: DataHubClient, owner_urns: List[str]) -> None:
@@ -90,7 +190,7 @@ def _validate_owner_urns(client: DataHubClient, owner_urns: List[str]) -> None:
 def _batch_modify_owners(
     owner_urns: List[str],
     entity_urns: List[str],
-    ownership_type: Optional[OwnershipType],
+    ownership_type: Optional[OwnershipTypeInput],
     operation: Literal["add", "remove"],
 ) -> dict:
     """
@@ -115,8 +215,12 @@ def _batch_modify_owners(
         resource_input = {"resourceUrn": resource_urn}
         resources.append(resource_input)
 
-    # Convert ownership type to URN if provided
-    ownership_type_urn = ownership_type.to_urn() if ownership_type else None
+    # Resolve & validate ownership type (built-in enum or custom URN/id)
+    ownership_type_urn = (
+        _resolve_ownership_type_urn(client, ownership_type)
+        if ownership_type is not None
+        else None
+    )
 
     # Determine mutation and operation name based on operation type
     if operation == "add":
@@ -203,7 +307,7 @@ def _batch_modify_owners(
 def add_owners(
     owner_urns: List[str],
     entity_urns: List[str],
-    ownership_type: OwnershipType,
+    ownership_type: OwnershipTypeInput,
 ) -> dict:
     """Add one or more owners to multiple DataHub entities.
 
@@ -217,10 +321,14 @@ def add_owners(
         owner_urns: List of owner URNs to add (must be CorpUser or CorpGroup URNs).
                    Examples: ["urn:li:corpuser:john.doe", "urn:li:corpGroup:data-engineering"]
         entity_urns: List of entity URNs to assign ownership to (e.g., dataset URNs, dashboard URNs)
-        ownership_type: The type of ownership to assign. Must be one of:
-                       - OwnershipType.TECHNICAL_OWNER: Involved in production, maintenance, or distribution
-                       - OwnershipType.BUSINESS_OWNER: Principle stakeholders or domain experts
-                       - OwnershipType.DATA_STEWARD: Involved in governance
+        ownership_type: The type of ownership to assign. Accepts either:
+                       - A built-in OwnershipType enum value:
+                         - TECHNICAL_OWNER: Involved in production, maintenance, or distribution
+                         - BUSINESS_OWNER: Principle stakeholders or domain experts
+                         - DATA_STEWARD: Involved in governance
+                       - A custom ownership type, passed by its user-facing name
+                         (e.g. "Producer"). Custom types are looked up by name
+                         (case-insensitive) via GraphQL and must already exist.
 
     Returns:
         Dictionary with:
@@ -235,7 +343,7 @@ def add_owners(
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
             ],
-            ownership_type=OwnershipType.TECHNICAL_OWNER
+            ownership_type=TECHNICAL_OWNER
         )
 
         # Add business owner
@@ -245,7 +353,7 @@ def add_owners(
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
             ],
-            ownership_type=OwnershipType.BUSINESS_OWNER
+            ownership_type=BUSINESS_OWNER
         )
 
         # Add data steward to multiple entities
@@ -256,7 +364,7 @@ def add_owners(
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.transactions,PROD)",
                 "urn:li:dashboard:(urn:li:dataPlatform:looker,sales_dashboard,PROD)"
             ],
-            ownership_type=OwnershipType.DATA_STEWARD
+            ownership_type=DATA_STEWARD
         )
     """
     return _batch_modify_owners(owner_urns, entity_urns, ownership_type, "add")
@@ -266,7 +374,7 @@ def add_owners(
 def remove_owners(
     owner_urns: List[str],
     entity_urns: List[str],
-    ownership_type: Optional[OwnershipType] = None,
+    ownership_type: Optional[OwnershipTypeInput] = None,
 ) -> dict:
     """Remove one or more owners from multiple DataHub entities.
 
@@ -282,10 +390,10 @@ def remove_owners(
         entity_urns: List of entity URNs to remove ownership from (e.g., dataset URNs, dashboard URNs)
         ownership_type: Optional ownership type to specify which type of ownership to remove.
                        If not provided, will remove ownership regardless of type.
-                       Can be one of:
-                       - OwnershipType.TECHNICAL_OWNER
-                       - OwnershipType.BUSINESS_OWNER
-                       - OwnershipType.DATA_STEWARD
+                       Accepts either a built-in OwnershipType enum value
+                       (TECHNICAL_OWNER, BUSINESS_OWNER, DATA_STEWARD) or a custom ownership
+                       type by its user-facing name (e.g. "Producer"). Custom types are looked
+                       up by name (case-insensitive) and must already exist in DataHub.
 
     Returns:
         Dictionary with:
@@ -309,7 +417,7 @@ def remove_owners(
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
             ],
-            ownership_type=OwnershipType.TECHNICAL_OWNER
+            ownership_type=TECHNICAL_OWNER
         )
 
         # Remove temporary owner from multiple entities

--- a/tests/test_mcp/test_mcp_server_helpers.py
+++ b/tests/test_mcp/test_mcp_server_helpers.py
@@ -1,3 +1,5 @@
+import importlib
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -531,6 +533,11 @@ def test_truncate_query_short() -> None:
 
 
 def test_truncate_descriptions() -> None:
+    """Test that truncate_descriptions sanitizes and truncates at ALL nesting levels.
+
+    Previously, recursive calls omitted max_length so nested descriptions reverted to
+    the default limit.  After the bug fix every level respects the caller's max_length.
+    """
     result = {
         "downstreams": {
             "searchResults": [
@@ -558,22 +565,29 @@ def test_truncate_descriptions() -> None:
 
     truncate_descriptions(result, 50)
 
+    # After the recursive-propagation fix, max_length=50 is honoured at every
+    # nesting depth.  truncate_with_ellipsis(text, 50) keeps the first 47 chars
+    # and appends "..." (3 chars) giving exactly 50 chars for long strings.
     assert result == {
         "downstreams": {
             "searchResults": [
                 {
                     "entity": {
-                        "description": "Description with image and more content that exceeds the limit",
+                        # Markdown image stripped → "…image…"; truncated at 50
+                        "description": "Description with image and more content that ex...",
                         "properties": {
-                            "description": "Description with image  and more content that exceeds the limit"
+                            # HTML tag stripped → double-space; truncated at 50
+                            "description": "Description with image  and more content that e..."
                         },
                         "fields": [
                             {
                                 "fieldPath": "description",
-                                "description": "Description with image  and more content that exceeds the limit",
+                                # Same as properties.description above
+                                "description": "Description with image  and more content that e...",
                             },
                             {
                                 "fieldPath": "description",
+                                # 18 chars — under the limit, unchanged
                                 "description": "Simple description",
                             },
                         ],
@@ -582,6 +596,22 @@ def test_truncate_descriptions() -> None:
             ]
         }
     }
+
+
+def test_description_length_limit_default() -> None:
+    """DESCRIPTION_LENGTH_HARD_LIMIT should default to 5000 (raised from hardcoded 1000)."""
+    assert graphql_helpers.DESCRIPTION_LENGTH_HARD_LIMIT == 5000
+
+
+def test_description_length_limit_env_var() -> None:
+    """DESCRIPTION_LENGTH_LIMIT env var should override the default at import time."""
+    with patch.dict(os.environ, {"DESCRIPTION_LENGTH_LIMIT": "2500"}):
+        importlib.reload(graphql_helpers)
+        assert graphql_helpers.DESCRIPTION_LENGTH_HARD_LIMIT == 2500
+
+    # Restore module to its default state (env var no longer set)
+    importlib.reload(graphql_helpers)
+    assert graphql_helpers.DESCRIPTION_LENGTH_HARD_LIMIT == 5000
 
 
 def test_get_lineage_normalizes_null_string() -> None:

--- a/tests/test_mcp/tools/test_owners.py
+++ b/tests/test_mcp/tools/test_owners.py
@@ -517,6 +517,367 @@ def test_remove_owners_mutation_returns_false(mock_datahub_client):
             remove_owners(owner_urns=owner_urns, entity_urns=entity_urns)
 
 
+# ===== Tests for custom ownership types =====
+
+
+def test_add_owners_with_custom_ownership_type_by_name(mock_datahub_client):
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+    custom_urn = "urn:li:ownershipType:abc-123"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        # _validate_owner_urns
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        # _resolve_ownership_type_urn — listOwnershipTypes by name
+        {
+            "listOwnershipTypes": {
+                "ownershipTypes": [
+                    {"urn": custom_urn, "info": {"name": "Producer"}},
+                ]
+            }
+        },
+        # mutation
+        {"batchAddOwners": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_owners(
+            owner_urns=owner_urns,
+            entity_urns=entity_urns,
+            ownership_type="Producer",
+        )
+
+    assert result["success"] is True
+    assert mock_datahub_client._graph.execute_graphql.call_count == 3
+
+    lookup_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert lookup_call.kwargs["operation_name"] == "listOwnershipTypes"
+    assert lookup_call.kwargs["variables"]["input"]["query"] == "Producer"
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    variables = mutation_call.kwargs["variables"]
+    assert variables["input"]["owners"][0]["ownershipTypeUrn"] == custom_urn
+    assert variables["input"]["ownershipTypeUrn"] == custom_urn
+
+
+def test_add_owners_with_custom_ownership_type_case_insensitive(mock_datahub_client):
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+    expected_urn = "urn:li:ownershipType:abc-123"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        # Server returns extra non-matching entries (listOwnershipTypes does
+        # prefix/partial matching) — we must filter down to the exact name.
+        {
+            "listOwnershipTypes": {
+                "ownershipTypes": [
+                    {
+                        "urn": "urn:li:ownershipType:producer-lead",
+                        "info": {"name": "Producer Lead"},
+                    },
+                    {"urn": expected_urn, "info": {"name": "Producer"}},
+                ]
+            }
+        },
+        {"batchAddOwners": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_owners(
+            owner_urns=owner_urns,
+            entity_urns=entity_urns,
+            ownership_type="producer",
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert (
+        mutation_call.kwargs["variables"]["input"]["ownershipTypeUrn"] == expected_urn
+    )
+
+
+def test_add_owners_with_nonexistent_custom_ownership_type(mock_datahub_client):
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        # No matches
+        {"listOwnershipTypes": {"ownershipTypes": []}},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match=r"was not found in DataHub"):
+            add_owners(
+                owner_urns=owner_urns,
+                entity_urns=entity_urns,
+                ownership_type="does-not-exist",
+            )
+
+
+def test_add_owners_with_partial_name_match_only_is_not_found(mock_datahub_client):
+    # listOwnershipTypes may return prefix/partial matches — if no exact name match,
+    # treat as not-found rather than silently picking one.
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        {
+            "listOwnershipTypes": {
+                "ownershipTypes": [
+                    {
+                        "urn": "urn:li:ownershipType:producer-lead",
+                        "info": {"name": "Producer Lead"},
+                    },
+                ]
+            }
+        },
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match=r"was not found in DataHub"):
+            add_owners(
+                owner_urns=owner_urns,
+                entity_urns=entity_urns,
+                ownership_type="Producer",
+            )
+
+
+def test_add_owners_with_ambiguous_custom_ownership_type(mock_datahub_client):
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        {
+            "listOwnershipTypes": {
+                "ownershipTypes": [
+                    {
+                        "urn": "urn:li:ownershipType:producer-a",
+                        "info": {"name": "Producer"},
+                    },
+                    {
+                        "urn": "urn:li:ownershipType:producer-b",
+                        "info": {"name": "producer"},
+                    },
+                ]
+            }
+        },
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match=r"ambiguous"):
+            add_owners(
+                owner_urns=owner_urns,
+                entity_urns=entity_urns,
+                ownership_type="Producer",
+            )
+
+
+def test_add_owners_with_empty_custom_ownership_type(mock_datahub_client):
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entities": [
+            {
+                "urn": "urn:li:corpuser:john.doe",
+                "type": "CORP_USER",
+                "username": "john.doe",
+            }
+        ]
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="non-empty string"):
+            add_owners(
+                owner_urns=["urn:li:corpuser:john.doe"],
+                entity_urns=["urn:li:dataset:test"],
+                ownership_type="   ",
+            )
+
+
+def test_remove_owners_with_custom_ownership_type(mock_datahub_client):
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+    custom_urn = "urn:li:ownershipType:abc-123"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        {
+            "listOwnershipTypes": {
+                "ownershipTypes": [
+                    {"urn": custom_urn, "info": {"name": "Producer"}},
+                ]
+            }
+        },
+        {"batchRemoveOwners": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = remove_owners(
+            owner_urns=owner_urns,
+            entity_urns=entity_urns,
+            ownership_type="Producer",
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert mutation_call.kwargs["variables"]["input"]["ownershipTypeUrn"] == custom_urn
+
+
+def test_add_owners_with_builtin_enum_name_string(mock_datahub_client):
+    # "TECHNICAL_OWNER" (enum name) should resolve via fast-path without a
+    # GraphQL lookup for the ownership type.
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+    expected_urn = "urn:li:ownershipType:__system__technical_owner"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        {"batchAddOwners": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_owners(
+            owner_urns=owner_urns,
+            entity_urns=entity_urns,
+            ownership_type="TECHNICAL_OWNER",
+        )
+
+    assert result["success"] is True
+    # Only 2 calls: owner validation + mutation. No ownership type lookup.
+    assert mock_datahub_client._graph.execute_graphql.call_count == 2
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert (
+        mutation_call.kwargs["variables"]["input"]["ownershipTypeUrn"] == expected_urn
+    )
+
+
+def test_add_owners_with_builtin_enum_value_string(mock_datahub_client):
+    # The enum value string ("__system__technical_owner") should also fast-path
+    # without requiring a GraphQL lookup.
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+    expected_urn = "urn:li:ownershipType:__system__technical_owner"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        {"batchAddOwners": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_owners(
+            owner_urns=owner_urns,
+            entity_urns=entity_urns,
+            ownership_type="__system__technical_owner",
+        )
+
+    assert result["success"] is True
+    assert mock_datahub_client._graph.execute_graphql.call_count == 2
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert (
+        mutation_call.kwargs["variables"]["input"]["ownershipTypeUrn"] == expected_urn
+    )
+
+
+def test_add_owners_with_builtin_full_urn_string(mock_datahub_client):
+    # Passing the full ownership type URN (e.g. "urn:li:ownershipType:__system__technical_owner")
+    # should fast-path to the built-in enum without a GraphQL lookup.
+    owner_urns = ["urn:li:corpuser:john.doe"]
+    entity_urns = ["urn:li:dataset:test"]
+    expected_urn = "urn:li:ownershipType:__system__technical_owner"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entities": [
+                {"urn": owner_urns[0], "type": "CORP_USER", "username": "john.doe"}
+            ]
+        },
+        {"batchAddOwners": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_owners(
+            owner_urns=owner_urns,
+            entity_urns=entity_urns,
+            ownership_type="urn:li:ownershipType:__system__technical_owner",
+        )
+
+    assert result["success"] is True
+    # Only 2 calls: owner validation + mutation. No ownership type lookup.
+    assert mock_datahub_client._graph.execute_graphql.call_count == 2
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert (
+        mutation_call.kwargs["variables"]["input"]["ownershipTypeUrn"] == expected_urn
+    )
+    assert (
+        mutation_call.kwargs["variables"]["input"]["owners"][0]["ownershipTypeUrn"]
+        == expected_urn
+    )
+
+
 def test_remove_owners_graphql_exception(mock_datahub_client):
     """Test handling of GraphQL execution exception."""
     owner_urns = ["urn:li:corpuser:test"]


### PR DESCRIPTION
sync mcp server changes
- owners fix for ownership types
- larger description lengths `DESCRIPTION_LENGTH_HARD_LIMIT`
- fix dataset name queries