### PR TITLE
Sync DATA_QUALITY_TOOLS module-level constant from cloud

### DIFF
--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -119,6 +119,15 @@ class ToolType(Enum):
     DEFAULT = "default"  # Fallback tag
 
 
+DATA_QUALITY_TOOLS = [
+    (
+        "get_dataset_assertions",
+        get_dataset_assertions,
+        {ToolType.SEARCH.value},
+    ),
+]
+
+
 # See https://github.com/jlowin/fastmcp/issues/864#issuecomment-3103678258
 # for why we need to wrap sync functions with asyncify.
 def async_background(fn: Callable[_P, _R]) -> Callable[_P, Awaitable[_R]]:
@@ -390,12 +399,8 @@ def register_data_quality_tools(mcp_instance: FastMCP, is_oss: bool = False) -> 
     if not enabled:
         return
 
-    _register_tool(
-        mcp_instance,
-        "get_dataset_assertions",
-        get_dataset_assertions,
-        tags={ToolType.SEARCH.value},
-    )
+    for name, fn, tags in DATA_QUALITY_TOOLS:
+        _register_tool(mcp_instance, name, fn, tags=tags)
 
 
 def register_all_tools(is_oss: bool = False) -> None:


### PR DESCRIPTION
## Summary

- Add a module-level `DATA_QUALITY_TOOLS` list to `mcp_server.py` and have `register_data_quality_tools` iterate over it, mirroring the structure used in the Cloud counterpart of this shared file (per the file's own header).
- No behavior change: the only registered data-quality tool remains `get_dataset_assertions`, still gated by `DATA_QUALITY_TOOLS_ENABLED` (default off).

## Why

`mcp_server.py` is intentionally kept in sync between this repo and the Cloud variant. Cloud recently introduced a `DATA_QUALITY_TOOLS` constant so that other Cloud-side consumers can iterate over the same list of (name, fn, tags) tuples that the registration loop uses. Propagating the constant here keeps the two files structurally aligned and makes future syncs mechanical.

## Test plan

- [x] `make lint` (ruff + mypy) clean
- [ ] `make test` not run locally (requires a live DataHub instance); CI will exercise the registration loop end-to-end