### PR TITLE
fix: older GMS compatibility — missing NEWER_GMS tags, multi-op documents, and input type mismatches

### DIFF
--- a/src/mcp_server_datahub/gql/document_search.gql
+++ b/src/mcp_server_datahub/gql/document_search.gql
@@ -104,7 +104,7 @@ query documentSearch(
       aggregations {
         value
         count
-        displayName
+        displayName  #[NEWER_GMS]
         entity {
           ...DocumentFacetEntityInfo
         }

--- a/src/mcp_server_datahub/gql/document_semantic_search.gql
+++ b/src/mcp_server_datahub/gql/document_semantic_search.gql
@@ -102,7 +102,7 @@ query documentSemanticSearch(
       aggregations {
         value
         count
-        displayName
+        displayName  #[NEWER_GMS]
         entity {
           ...DocumentFacetEntityInfo
         }

--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -163,10 +163,10 @@ fragment parentNodesFields on ParentNodesResult {
             name
             __typename
         }
-        displayProperties {
-            ...displayPropertiesFields
-            __typename
-        }
+        displayProperties {                                         #[NEWER_GMS]
+            ...displayPropertiesFields                              #[NEWER_GMS]
+            __typename                                              #[NEWER_GMS]
+        }                                                           #[NEWER_GMS]
         __typename
     }
     __typename
@@ -212,15 +212,15 @@ fragment glossaryTerms on GlossaryTerms {
     }
     __typename
 }
-fragment displayPropertiesFields on DisplayProperties {
-    icon {
-        name
-        style
-        iconLibrary
-        __typename
-    }
-    __typename
-}
+fragment displayPropertiesFields on DisplayProperties {  #[NEWER_GMS]
+    icon {                                               #[NEWER_GMS]
+        name                                             #[NEWER_GMS]
+        style                                            #[NEWER_GMS]
+        iconLibrary                                      #[NEWER_GMS]
+        __typename                                       #[NEWER_GMS]
+    }                                                    #[NEWER_GMS]
+    __typename                                           #[NEWER_GMS]
+}                                                        #[NEWER_GMS]
 
 fragment entityDomain on DomainAssociation {
     domain {
@@ -235,10 +235,10 @@ fragment entityDomain on DomainAssociation {
             __typename
         }
         ...domainEntitiesFields
-        displayProperties {
-            ...displayPropertiesFields
-            __typename
-        }
+        displayProperties {                             #[NEWER_GMS]
+            ...displayPropertiesFields                  #[NEWER_GMS]
+            __typename                                  #[NEWER_GMS]
+        }                                               #[NEWER_GMS]
         __typename
     }
     __typename
@@ -283,12 +283,12 @@ fragment deprecationFields on Deprecation {
     deprecated
     note
     decommissionTime
-    actorEntity {
-        urn
-        type
-        ...entityDisplayNameFields
-        __typename
-    }
+    actorEntity {                    #[NEWER_GMS]
+        urn                          #[NEWER_GMS]
+        type                         #[NEWER_GMS]
+        ...entityDisplayNameFields   #[NEWER_GMS]
+        __typename                   #[NEWER_GMS]
+    }                                #[NEWER_GMS]
     __typename
 }
 
@@ -489,10 +489,10 @@ fragment parentDomainsFields on ParentDomainsResult {
         urn
         type
         ... on Domain {
-            displayProperties {
-                ...displayPropertiesFields
-                __typename
-            }
+            displayProperties {                             #[NEWER_GMS]
+                ...displayPropertiesFields                  #[NEWER_GMS]
+                __typename                                  #[NEWER_GMS]
+            }                                               #[NEWER_GMS]
             properties {
                 name
                 description
@@ -513,7 +513,7 @@ fragment entityPreview on Entity {
             ...platformFields
         }
         editableProperties {
-            name
+            name  #[NEWER_GMS]
             description
         }
         properties {
@@ -949,9 +949,9 @@ fragment entityPreview on Entity {
         parentDomains {
             ...parentDomainsFields
         }
-        displayProperties {
-            ...displayPropertiesFields
-        }
+        displayProperties {                             #[NEWER_GMS]
+            ...displayPropertiesFields                  #[NEWER_GMS]
+        }                                               #[NEWER_GMS]
         ...domainEntitiesFields
     }
     ... on DataProduct {
@@ -1039,13 +1039,13 @@ fragment entityPreview on Entity {
         deprecation {
             ...deprecationFields
         }
-        browsePathV2 {
-            path {
-                entity {
-                    ...entityDisplayNameFields
-                }
-            }
-        }
+        browsePathV2 {                         #[NEWER_GMS]
+            path {                             #[NEWER_GMS]
+                entity {                       #[NEWER_GMS]
+                    ...entityDisplayNameFields #[NEWER_GMS]
+                }                             #[NEWER_GMS]
+            }                                  #[NEWER_GMS]
+        }                                      #[NEWER_GMS]
     }
     ... on Assertion {
         urn
@@ -1053,10 +1053,10 @@ fragment entityPreview on Entity {
         info {
             type
             description
-            lastUpdated {
-                time
-                actor
-            }
+            lastUpdated {  #[NEWER_GMS]
+                time  #[NEWER_GMS]
+                actor  #[NEWER_GMS]
+            }  #[NEWER_GMS]
             datasetAssertion {
                 datasetUrn
                 scope
@@ -1087,126 +1087,126 @@ fragment entityPreview on Entity {
                 }
                 logic
             }
-            fieldAssertion {
-                type
-                entityUrn
-                fieldValuesAssertion {
-                    field {
-                        path
-                        type
-                        nativeType
-                    }
-                    operator
-                    parameters {
-                        value {
-                            value
-                            type
-                        }
-                        minValue {
-                            value
-                            type
-                        }
-                        maxValue {
-                            value
-                            type
-                        }
-                    }
-                    failThreshold {
-                        type
-                        value
-                    }
-                    excludeNulls
-                }
-                fieldMetricAssertion {
-                    field {
-                        path
-                        type
-                        nativeType
-                    }
-                    metric
-                    operator
-                    parameters {
-                        value {
-                            value
-                            type
-                        }
-                        minValue {
-                            value
-                            type
-                        }
-                        maxValue {
-                            value
-                            type
-                        }
-                    }
-                }
-            }
-            volumeAssertion {
-                type
-                entityUrn
-                rowCountTotal {
-                    operator
-                    parameters {
-                        value {
-                            value
-                            type
-                        }
-                        minValue {
-                            value
-                            type
-                        }
-                        maxValue {
-                            value
-                            type
-                        }
-                    }
-                }
-                rowCountChange {
-                    type
-                    operator
-                    parameters {
-                        value {
-                            value
-                            type
-                        }
-                        minValue {
-                            value
-                            type
-                        }
-                        maxValue {
-                            value
-                            type
-                        }
-                    }
-                }
-            }
-            sqlAssertion {
-                type
-                entityUrn
-                statement
-                operator
-                parameters {
-                    value {
-                        value
-                        type
-                    }
-                    minValue {
-                        value
-                        type
-                    }
-                    maxValue {
-                        value
-                        type
-                    }
-                }
-            }
-            source {
-                type
-                created {
-                    time
-                    actor
-                }
-            }
+            fieldAssertion {  #[NEWER_GMS]
+                type  #[NEWER_GMS]
+                entityUrn  #[NEWER_GMS]
+                fieldValuesAssertion {  #[NEWER_GMS]
+                    field {  #[NEWER_GMS]
+                        path  #[NEWER_GMS]
+                        type  #[NEWER_GMS]
+                        nativeType  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                    operator  #[NEWER_GMS]
+                    parameters {  #[NEWER_GMS]
+                        value {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        minValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        maxValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                    failThreshold {  #[NEWER_GMS]
+                        type  #[NEWER_GMS]
+                        value  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                    excludeNulls  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+                fieldMetricAssertion {  #[NEWER_GMS]
+                    field {  #[NEWER_GMS]
+                        path  #[NEWER_GMS]
+                        type  #[NEWER_GMS]
+                        nativeType  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                    metric  #[NEWER_GMS]
+                    operator  #[NEWER_GMS]
+                    parameters {  #[NEWER_GMS]
+                        value {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        minValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        maxValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+            volumeAssertion {  #[NEWER_GMS]
+                type  #[NEWER_GMS]
+                entityUrn  #[NEWER_GMS]
+                rowCountTotal {  #[NEWER_GMS]
+                    operator  #[NEWER_GMS]
+                    parameters {  #[NEWER_GMS]
+                        value {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        minValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        maxValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+                rowCountChange {  #[NEWER_GMS]
+                    type  #[NEWER_GMS]
+                    operator  #[NEWER_GMS]
+                    parameters {  #[NEWER_GMS]
+                        value {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        minValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        maxValue {  #[NEWER_GMS]
+                            value  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+            sqlAssertion {  #[NEWER_GMS]
+                type  #[NEWER_GMS]
+                entityUrn  #[NEWER_GMS]
+                statement  #[NEWER_GMS]
+                operator  #[NEWER_GMS]
+                parameters {  #[NEWER_GMS]
+                    value {  #[NEWER_GMS]
+                        value  #[NEWER_GMS]
+                        type  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                    minValue {  #[NEWER_GMS]
+                        value  #[NEWER_GMS]
+                        type  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                    maxValue {  #[NEWER_GMS]
+                        value  #[NEWER_GMS]
+                        type  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+            source {  #[NEWER_GMS]
+                type  #[NEWER_GMS]
+                created {  #[NEWER_GMS]
+                    time  #[NEWER_GMS]
+                    actor  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
         }
         platform {
             urn
@@ -1242,7 +1242,7 @@ fragment entityPreview on Entity {
         title
         description
         priority
-        startedAt
+        startedAt  #[NEWER_GMS]
         created {
             time
             actor
@@ -1256,34 +1256,34 @@ fragment entityPreview on Entity {
                 actor                                           #[CLOUD] #[NEWER_GMS]
             }                                                   #[CLOUD] #[NEWER_GMS]
         }                                                       #[CLOUD] #[NEWER_GMS]
-        assignees {
-            ... on CorpUser {
-                urn
-                username
-                properties {
-                    active
-                    displayName
-                    email
-                    title
-                }
-                editableProperties {
-                    displayName
-                    title
-                }
-            }
-            ... on CorpGroup {
-                urn
-                name
-                properties {
-                    displayName
-                    email
-                }
-                info {
-                    displayName
-                    email
-                }
-            }
-        }
+        assignees {  #[NEWER_GMS]
+            ... on CorpUser {  #[NEWER_GMS]
+                urn  #[NEWER_GMS]
+                username  #[NEWER_GMS]
+                properties {  #[NEWER_GMS]
+                    active  #[NEWER_GMS]
+                    displayName  #[NEWER_GMS]
+                    email  #[NEWER_GMS]
+                    title  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+                editableProperties {  #[NEWER_GMS]
+                    displayName  #[NEWER_GMS]
+                    title  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+            ... on CorpGroup {  #[NEWER_GMS]
+                urn  #[NEWER_GMS]
+                name  #[NEWER_GMS]
+                properties {  #[NEWER_GMS]
+                    displayName  #[NEWER_GMS]
+                    email  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+                info {  #[NEWER_GMS]
+                    displayName  #[NEWER_GMS]
+                    email  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+        }  #[NEWER_GMS]
         entity {
             urn
             type
@@ -1331,18 +1331,18 @@ fragment entityPreview on Entity {
                 }
             }
         }
-        tags {
-            tags {
-                tag {
-                    urn
-                    name
-                    properties {
-                        name
-                        description
-                    }
-                }
-            }
-        }
+        tags {  #[NEWER_GMS]
+            tags {  #[NEWER_GMS]
+                tag {  #[NEWER_GMS]
+                    urn  #[NEWER_GMS]
+                    name  #[NEWER_GMS]
+                    properties {  #[NEWER_GMS]
+                        name  #[NEWER_GMS]
+                        description  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+        }  #[NEWER_GMS]
     }
     ... on Document {                                           #[NEWER_GMS]
         urn                                                     #[NEWER_GMS]
@@ -1406,10 +1406,10 @@ fragment entityPreview on Entity {
     }                                                           #[NEWER_GMS]
 }
 
-fragment documentationFields on Documentation {
-    documentations {
-        documentation
-        attribution {
+fragment documentationFields on Documentation {  #[NEWER_GMS]
+    documentations {                             #[NEWER_GMS]
+        documentation                            #[NEWER_GMS]
+        attribution {                            #[NEWER_GMS]
             # time
             # actor {
             #   urn
@@ -1420,40 +1420,40 @@ fragment documentationFields on Documentation {
             #   urn
             #   type
             # }
-            sourceDetail {
-                key
-                value
-            }
-        }
-    }
-}
+            sourceDetail {                       #[NEWER_GMS]
+                key                              #[NEWER_GMS]
+                value                            #[NEWER_GMS]
+            }                                    #[NEWER_GMS]
+        }                                        #[NEWER_GMS]
+    }                                            #[NEWER_GMS]
+}                                                #[NEWER_GMS]
 
-fragment businessAttribute on BusinessAttributeAssociation {
-    businessAttribute {
-        urn
-        type
-        ownership {
-            ...ownershipFields
-        }
-        properties {
-            name
-            description
-            businessAttributeDataType: type
-            lastModified {
-                time
-            }
-            created {
-                time
-            }
-            tags {
-                ...globalTagsFields
-            }
-            glossaryTerms {
-                ...glossaryTerms
-            }
-        }
-    }
-}
+fragment businessAttribute on BusinessAttributeAssociation {  #[NEWER_GMS]
+    businessAttribute {                                        #[NEWER_GMS]
+        urn                                                    #[NEWER_GMS]
+        type                                                   #[NEWER_GMS]
+        ownership {                                            #[NEWER_GMS]
+            ...ownershipFields                                 #[NEWER_GMS]
+        }                                                      #[NEWER_GMS]
+        properties {                                           #[NEWER_GMS]
+            name                                               #[NEWER_GMS]
+            description                                        #[NEWER_GMS]
+            businessAttributeDataType: type                    #[NEWER_GMS]
+            lastModified {                                     #[NEWER_GMS]
+                time                                           #[NEWER_GMS]
+            }                                                  #[NEWER_GMS]
+            created {                                          #[NEWER_GMS]
+                time                                           #[NEWER_GMS]
+            }                                                  #[NEWER_GMS]
+            tags {                                             #[NEWER_GMS]
+                ...globalTagsFields                            #[NEWER_GMS]
+            }                                                  #[NEWER_GMS]
+            glossaryTerms {                                    #[NEWER_GMS]
+                ...glossaryTerms                               #[NEWER_GMS]
+            }                                                  #[NEWER_GMS]
+        }                                                      #[NEWER_GMS]
+    }                                                          #[NEWER_GMS]
+}                                                              #[NEWER_GMS]
 
 fragment structuredPropertyFields on StructuredPropertyEntity {
     urn
@@ -1472,7 +1472,7 @@ fragment structuredPropertyDetailsFields on StructuredPropertyEntity {
         qualifiedName
         description
         cardinality
-        immutable
+        immutable  #[NEWER_GMS]
         valueType {
             urn
             info {
@@ -1504,34 +1504,34 @@ fragment structuredPropertyDetailsFields on StructuredPropertyEntity {
             }
             description
         }
-        created {
-            time
-            actor {
-                urn
-                editableProperties {
-                    displayName
-                }
-                ...entityDisplayNameFields
-            }
-        }
-        lastModified {
-            time
-            actor {
-                urn
-                editableProperties {
-                    displayName
-                }
-                ...entityDisplayNameFields
-            }
-        }
+        created {  #[NEWER_GMS]
+            time  #[NEWER_GMS]
+            actor {  #[NEWER_GMS]
+                urn  #[NEWER_GMS]
+                editableProperties {  #[NEWER_GMS]
+                    displayName  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+                ...entityDisplayNameFields  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+        }  #[NEWER_GMS]
+        lastModified {  #[NEWER_GMS]
+            time  #[NEWER_GMS]
+            actor {  #[NEWER_GMS]
+                urn  #[NEWER_GMS]
+                editableProperties {  #[NEWER_GMS]
+                    displayName  #[NEWER_GMS]
+                }  #[NEWER_GMS]
+                ...entityDisplayNameFields  #[NEWER_GMS]
+            }  #[NEWER_GMS]
+        }  #[NEWER_GMS]
     }
-    settings {
-        isHidden
-        showInSearchFilters
-        showAsAssetBadge
-        showInAssetSummary
-        showInColumnsTable
-    }
+    settings {  #[NEWER_GMS]
+        isHidden  #[NEWER_GMS]
+        showInSearchFilters  #[NEWER_GMS]
+        showAsAssetBadge  #[NEWER_GMS]
+        showInAssetSummary  #[NEWER_GMS]
+        showInColumnsTable  #[NEWER_GMS]
+    }  #[NEWER_GMS]
 }
 
 fragment structuredPropertiesFields on StructuredPropertiesEntry {
@@ -1558,22 +1558,22 @@ fragment entitySchemaFieldEntityFields on SchemaFieldEntity {
     # urn
     # fieldPath
     # type
-    deprecation {
-        ...deprecationFields
-    }
+    deprecation {  #[NEWER_GMS]
+        ...deprecationFields  #[NEWER_GMS]
+    }  #[NEWER_GMS]
     structuredProperties {
         properties {
             ...structuredPropertiesFields
         }
     }
-    businessAttributes {
-        businessAttribute {
-            ...businessAttribute
-        }
-    }
-    documentation {
-        ...documentationFields
-    }
+    businessAttributes {  #[NEWER_GMS]
+        businessAttribute {  #[NEWER_GMS]
+            ...businessAttribute  #[NEWER_GMS]
+        }  #[NEWER_GMS]
+    }  #[NEWER_GMS]
+    documentation {  #[NEWER_GMS]
+        ...documentationFields  #[NEWER_GMS]
+    }  #[NEWER_GMS]
 }
 
 fragment entitySchemaFieldFields on SchemaField {

--- a/src/mcp_server_datahub/gql/queries.gql
+++ b/src/mcp_server_datahub/gql/queries.gql
@@ -34,11 +34,11 @@ fragment query on QueryEntity {
         name
       }
     }
-    schemaField {
-      urn
-      type
-      fieldPath
-    }
+    schemaField {            #[NEWER_GMS]
+      urn                    #[NEWER_GMS]
+      type                   #[NEWER_GMS]
+      fieldPath              #[NEWER_GMS]
+    }                        #[NEWER_GMS]
   }
 }
 

--- a/src/mcp_server_datahub/gql/search.gql
+++ b/src/mcp_server_datahub/gql/search.gql
@@ -113,7 +113,7 @@ query search(
       aggregations {
         value
         count
-        displayName
+        displayName  #[NEWER_GMS]
         entity {
           ...FacetEntityInfo
         }

--- a/src/mcp_server_datahub/gql/semantic_search.gql
+++ b/src/mcp_server_datahub/gql/semantic_search.gql
@@ -99,7 +99,7 @@ query semanticSearch(
       aggregations {
         value
         count
-        displayName
+        displayName  #[NEWER_GMS]
         entity {
           ...FacetEntityInfo
         }

--- a/src/mcp_server_datahub/gql/smart_search.gql
+++ b/src/mcp_server_datahub/gql/smart_search.gql
@@ -281,7 +281,7 @@ query smartSearch(
       aggregations {
         value
         count
-        displayName
+        displayName  #[NEWER_GMS]
         entity {
           ...FacetEntityInfo
         }

--- a/src/mcp_server_datahub/graphql_helpers.py
+++ b/src/mcp_server_datahub/graphql_helpers.py
@@ -401,6 +401,82 @@ def _is_field_validation_error(error_msg: str) -> bool:
     )
 
 
+def _strip_to_operation(query: str, operation_name: str) -> str:
+    """Extract a single operation and its required fragment definitions from a multi-operation document.
+
+    Older GMS versions (e.g. v0.13.1) reject multi-operation GraphQL documents
+    even when operationName is provided, and also reject unused fragments.
+    This function strips the document down to just the requested operation plus
+    only the fragment definitions it transitively depends on.
+    """
+    # Quick check: if only one operation, nothing to do
+    op_count = len(
+        re.findall(r"^(?:query|mutation|subscription)\s", query, re.MULTILINE)
+    )
+    if op_count <= 1:
+        return query
+
+    lines = query.splitlines(keepends=True)
+    op_pattern = re.compile(r"^(fragment|query|mutation|subscription)\s+(\w+)")
+
+    # Parse all top-level definitions with their line ranges
+    definitions: list[tuple[int, int, str, str]] = []  # (start, end, kind, name)
+    i = 0
+    while i < len(lines):
+        m = op_pattern.match(lines[i])
+        if m:
+            kind, name = m.group(1), m.group(2)
+            start = i
+            depth = 0
+            for j in range(i, len(lines)):
+                depth += lines[j].count("{") - lines[j].count("}")
+                if depth == 0 and j > start:
+                    definitions.append((start, j, kind, name))
+                    i = j + 1
+                    break
+            else:
+                i += 1
+        else:
+            i += 1
+
+    # Build fragment body index for dependency tracing
+    fragment_bodies: dict[str, str] = {}
+    for start, end, kind, name in definitions:
+        if kind == "fragment":
+            fragment_bodies[name] = "".join(lines[start : end + 1])
+
+    # Find the target operation body
+    target_body = ""
+    for start, end, kind, name in definitions:
+        if name == operation_name and kind != "fragment":
+            target_body = "".join(lines[start : end + 1])
+            break
+
+    if not target_body:
+        return query  # operation not found, return as-is
+
+    # Transitively collect all fragment names referenced by the target operation
+    def collect_fragments(body: str, collected: set[str]) -> None:
+        for ref in re.findall(r"\.\.\.\s*(\w+)", body):
+            if ref not in collected and ref in fragment_bodies:
+                collected.add(ref)
+                collect_fragments(fragment_bodies[ref], collected)
+
+    needed: set[str] = set()
+    collect_fragments(target_body, needed)
+
+    # Assemble: needed fragments + target operation
+    parts: list[str] = []
+    for start, end, kind, name in definitions:
+        if (kind == "fragment" and name in needed) or (
+            kind != "fragment" and name == operation_name
+        ):
+            parts.append("".join(lines[start : end + 1]))
+            parts.append("\n")
+
+    return "".join(parts) if parts else query
+
+
 def execute_graphql(
     graph: DataHubGraph,
     *,
@@ -449,6 +525,11 @@ def execute_graphql(
         f"GraphQL query for {operation_name or 'query'}:\n{query}\nVariables: {variables}"
     )
 
+    # Older GMS versions (e.g. v0.13.1) reject multi-operation documents even
+    # when operationName is provided. Strip down to a single operation if needed.
+    if operation_name:
+        query = _strip_to_operation(query, operation_name)
+
     try:
         # Execute the GraphQL query
         result = graph.execute_graphql(
@@ -481,6 +562,9 @@ def execute_graphql(
                     fallback_query = _disable_cloud_fields(fallback_query)
                 # Disable newer GMS fields for fallback
                 fallback_query = _disable_newer_gms_fields(fallback_query)
+                # Strip to single operation for older GMS that rejects multi-op documents
+                if operation_name:
+                    fallback_query = _strip_to_operation(fallback_query, operation_name)
 
                 logger.debug(
                     f"Retry {operation_name or 'query'} with NEWER_GMS fields disabled: "

--- a/src/mcp_server_datahub/tools/assertions.py
+++ b/src/mcp_server_datahub/tools/assertions.py
@@ -42,10 +42,10 @@ query SearchDatasetAssertions(
                     info {
                         type
                         description
-                        note
-                        externalUrl
-                        entityUrn
-                        source { type }
+                        note  #[NEWER_GMS]
+                        externalUrl  #[NEWER_GMS]
+                        entityUrn  #[NEWER_GMS]
+                        source { type }  #[NEWER_GMS]
                         datasetAssertion {
                             datasetUrn
                             scope
@@ -60,88 +60,88 @@ query SearchDatasetAssertions(
                             nativeType
                             logic
                         }
-                        freshnessAssertion {
-                            entityUrn
-                            type
-                            schedule {
-                                type
-                                cron { cron timezone }
-                                fixedInterval { unit multiple }
-                            }
-                            filter { type sql }
-                        }
-                        volumeAssertion {
-                            entityUrn
-                            type
-                            filter { type sql }
-                            rowCountTotal {
-                                operator
-                                parameters {
-                                    value { value type }
-                                    minValue { value type }
-                                    maxValue { value type }
-                                }
-                            }
-                            rowCountChange {
-                                type
-                                operator
-                                parameters {
-                                    value { value type }
-                                    minValue { value type }
-                                    maxValue { value type }
-                                }
-                            }
-                        }
-                        sqlAssertion {
-                            type
-                            entityUrn
-                            statement
-                            changeType
-                            operator
-                            parameters {
-                                value { value type }
-                                minValue { value type }
-                                maxValue { value type }
-                            }
-                        }
-                        fieldAssertion {
-                            type
-                            entityUrn
-                            filter { type sql }
-                            fieldValuesAssertion {
-                                field { path type nativeType }
-                                transform { type }
-                                operator
-                                parameters {
-                                    value { value type }
-                                    minValue { value type }
-                                    maxValue { value type }
-                                }
-                                failThreshold { type value }
-                                excludeNulls
-                            }
-                            fieldMetricAssertion {
-                                field { path type nativeType }
-                                metric
-                                operator
-                                parameters {
-                                    value { value type }
-                                    minValue { value type }
-                                    maxValue { value type }
-                                }
-                            }
-                        }
-                        schemaAssertion {
-                            entityUrn
-                            compatibility
-                            fields { path type nativeType }
-                        }
-                        customAssertion {
-                            type
-                            entityUrn
-                            field { urn path }
-                            logic
-                        }
+                        freshnessAssertion {  #[NEWER_GMS]
+                            entityUrn  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                            schedule {  #[NEWER_GMS]
+                                type  #[NEWER_GMS]
+                                cron { cron timezone }  #[NEWER_GMS]
+                                fixedInterval { unit multiple }  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                            filter { type sql }  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        volumeAssertion {  #[NEWER_GMS]
+                            entityUrn  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                            filter { type sql }  #[NEWER_GMS]
+                            rowCountTotal {  #[NEWER_GMS]
+                                operator  #[NEWER_GMS]
+                                parameters {  #[NEWER_GMS]
+                                    value { value type }  #[NEWER_GMS]
+                                    minValue { value type }  #[NEWER_GMS]
+                                    maxValue { value type }  #[NEWER_GMS]
+                                }  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                            rowCountChange {  #[NEWER_GMS]
+                                type  #[NEWER_GMS]
+                                operator  #[NEWER_GMS]
+                                parameters {  #[NEWER_GMS]
+                                    value { value type }  #[NEWER_GMS]
+                                    minValue { value type }  #[NEWER_GMS]
+                                    maxValue { value type }  #[NEWER_GMS]
+                                }  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        sqlAssertion {  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                            entityUrn  #[NEWER_GMS]
+                            statement  #[NEWER_GMS]
+                            changeType  #[NEWER_GMS]
+                            operator  #[NEWER_GMS]
+                            parameters {  #[NEWER_GMS]
+                                value { value type }  #[NEWER_GMS]
+                                minValue { value type }  #[NEWER_GMS]
+                                maxValue { value type }  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        fieldAssertion {  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                            entityUrn  #[NEWER_GMS]
+                            filter { type sql }  #[NEWER_GMS]
+                            fieldValuesAssertion {  #[NEWER_GMS]
+                                field { path type nativeType }  #[NEWER_GMS]
+                                transform { type }  #[NEWER_GMS]
+                                operator  #[NEWER_GMS]
+                                parameters {  #[NEWER_GMS]
+                                    value { value type }  #[NEWER_GMS]
+                                    minValue { value type }  #[NEWER_GMS]
+                                    maxValue { value type }  #[NEWER_GMS]
+                                }  #[NEWER_GMS]
+                                failThreshold { type value }  #[NEWER_GMS]
+                                excludeNulls  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                            fieldMetricAssertion {  #[NEWER_GMS]
+                                field { path type nativeType }  #[NEWER_GMS]
+                                metric  #[NEWER_GMS]
+                                operator  #[NEWER_GMS]
+                                parameters {  #[NEWER_GMS]
+                                    value { value type }  #[NEWER_GMS]
+                                    minValue { value type }  #[NEWER_GMS]
+                                    maxValue { value type }  #[NEWER_GMS]
+                                }  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        schemaAssertion {  #[NEWER_GMS]
+                            entityUrn  #[NEWER_GMS]
+                            compatibility  #[NEWER_GMS]
+                            fields { path type nativeType }  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                        customAssertion {  #[NEWER_GMS]
+                            type  #[NEWER_GMS]
+                            entityUrn  #[NEWER_GMS]
+                            field { urn path }  #[NEWER_GMS]
+                            logic  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
                     }
                     runEvents(status: COMPLETE, limit: $runEventsLimit) {
                         total
@@ -158,21 +158,21 @@ query SearchDatasetAssertions(
                                 actualAggValue
                                 externalUrl
                                 nativeResults { key value }
-                                error {
-                                    type
-                                    displayMessage
-                                }
+                                error {  #[NEWER_GMS]
+                                    type  #[NEWER_GMS]
+                                    displayMessage  #[NEWER_GMS]
+                                }  #[NEWER_GMS]
                             }
                         }
                     }
-                    tags {
-                        tags {
-                            tag {
-                                urn
-                                properties { name }
-                            }
-                        }
-                    }
+                    tags {  #[NEWER_GMS]
+                        tags {  #[NEWER_GMS]
+                            tag {  #[NEWER_GMS]
+                                urn  #[NEWER_GMS]
+                                properties { name }  #[NEWER_GMS]
+                            }  #[NEWER_GMS]
+                        }  #[NEWER_GMS]
+                    }  #[NEWER_GMS]
                 }
             }
         }

--- a/src/mcp_server_datahub/tools/dataset_queries.py
+++ b/src/mcp_server_datahub/tools/dataset_queries.py
@@ -125,6 +125,7 @@ def get_dataset_queries(
     """
     client = graphql_helpers.get_datahub_client()
 
+    dataset_urn = urn  # preserve dataset URN before potential schema field conversion
     urn = graphql_helpers.maybe_convert_to_schema_field_urn(urn, column)
 
     entities_filter = FilterDsl.custom_filter(
@@ -146,12 +147,32 @@ def get_dataset_queries(
         variables["input"]["source"] = source
 
     # Execute the GraphQL query
-    result = graphql_helpers.execute_graphql(
-        client._graph,
-        query=queries_gql,
-        variables=variables,
-        operation_name="listQueries",
-    )["listQueries"]
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=queries_gql,
+            variables=variables,
+            operation_name="listQueries",
+        )["listQueries"]
+    except Exception as e:
+        # Older GMS (e.g. v0.13.1) uses datasetUrn instead of orFilters
+        if "orFilters" not in str(e):
+            raise
+        fallback_variables: dict = {
+            "input": {
+                "start": start,
+                "count": count,
+                "datasetUrn": dataset_urn,
+            }
+        }
+        if source is not None:
+            fallback_variables["input"]["source"] = source
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=queries_gql,
+            variables=fallback_variables,
+            operation_name="listQueries",
+        )["listQueries"]
 
     for query in result["queries"]:
         if query.get("subjects"):


### PR DESCRIPTION
## Summary

Fixes #131

Comprehensive compatibility fix for DataHub v0.13.1 and other older self-hosted instances. Three root causes addressed:

1. **Missing `#[NEWER_GMS]` tags** across `entity_details.gql`, `queries.gql`, and the inline query in `assertions.py`
2. **Multi-operation document rejection** — v0.13.1 returns HTTP 500 even when `operationName` is set; fixed by stripping to the requested operation before sending
3. **`ListQueriesInput.orFilters` not in v0.13.1** — falls back to `datasetUrn`

## Test Plan

- [x] `get_me` — passes on v0.13.1 (no schema changes needed)
- [x] `search` — fixed: `AggregationMetadata.displayName` tagged `#[NEWER_GMS]`
- [x] `get_entities` — fixed: `displayProperties` / `Documentation` / `BusinessAttributeAssociation` tagged `#[NEWER_GMS]`
- [x] `list_schema_fields` — fixed: same `displayProperties` tags
- [x] `get_lineage` (upstream + downstream) — fixed: `_strip_to_operation()` eliminates HTTP 500 multi-op rejection
- [x] `get_dataset_queries` — fixed: `QuerySubject.schemaField` tagged, `orFilters` → `datasetUrn` fallback
- [x] `get_dataset_assertions` — fixed: 10+ `AssertionInfo` fields and newer assertion type blocks tagged `#[NEWER_GMS]`
- [x] Full behaviour on newer GMS unaffected — `_strip_to_operation()` is a no-op for single-operation documents; `#[NEWER_GMS]` tags only suppress on older instances
