### PR TITLE
feat(auth): adding auth for self-hosted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,21 @@ uv run fastmcp dev src/mcp_server_datahub/__main__.py --with-editable .
 
 ## Authentication
 
+### DataHub backend
+
 Server requires DataHub authentication via:
 
 - Environment variables: `DATAHUB_GMS_URL`, `DATAHUB_GMS_TOKEN`
 - Or `~/.datahubenv` configuration file
+
+### MCP server (client-facing)
+
+When running over HTTP/SSE transport, protect the server with bearer-token auth:
+
+- Set `DATAHUB_MCP_AUTH_TOKENS` to a comma-separated list of valid tokens
+- Tokens are verified by `StaticTokenAuthProvider` in `src/mcp_server_datahub/auth.py`
+- Auth is skipped for `stdio` transport (subprocess, no network exposure)
+- If unset, server starts open and logs a warning for HTTP transports
 
 ## Version Management
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Save standalone documents (insights, decisions, FAQs, notes) to DataHub's knowle
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `DATAHUB_MCP_AUTH_TOKENS` | _(unset)_ | Comma-separated bearer tokens for server authentication (HTTP/SSE transports only — see [Server Authentication](#server-authentication)) |
 | `TOOLS_IS_MUTATION_ENABLED` | `false` | Enable mutation tools (add/remove tags, owners, etc.) |
 | `TOOLS_IS_USER_ENABLED` | `false` | Enable user tools (get_me) |
 | `DATAHUB_MCP_DOCUMENT_TOOLS_DISABLED` | `false` | Completely disable document tools |
@@ -164,6 +165,42 @@ Save standalone documents (insights, decisions, FAQs, notes) to DataHub's knowle
 | `DISABLE_NEWER_GMS_FIELD_DETECTION` | `false` | Disable adaptive GMS field detection |
 | `DATAHUB_MCP_DISABLE_DEFAULT_VIEW` | `false` | Disable automatic default view application |
 | `SEMANTIC_SEARCH_ENABLED` | `false` | Enable semantic (AI-powered) search |
+
+### Server Authentication
+
+When running the MCP server over **HTTP or SSE transport** (i.e. as a shared, network-accessible service) you should protect it with bearer-token authentication.
+
+Set `DATAHUB_MCP_AUTH_TOKENS` to a comma-separated list of opaque tokens before starting the server:
+
+```bash
+export DATAHUB_MCP_AUTH_TOKENS="your-secret-token-1,your-secret-token-2"
+```
+
+Each token acts as a shared secret (similar to an API key).  Supporting multiple tokens lets you rotate credentials without downtime — distribute the new token to your team, then remove the old one.
+
+MCP clients must include the token as a standard HTTP `Authorization` header:
+
+```
+Authorization: Bearer your-secret-token-1
+```
+
+Most MCP clients (Claude Desktop, opencode, etc.) support bearer-token auth in their server configuration.  For example, in `opencode.jsonc`:
+
+```jsonc
+"datahub": {
+  "type": "remote",
+  "url": "https://your-datahub-mcp-server/mcp",
+  "headers": {
+    "Authorization": "Bearer your-secret-token-1"
+  }
+}
+```
+
+> **Notes:**
+> - Authentication only applies to HTTP and SSE transports.  The `stdio` transport runs as a local subprocess and has no network exposure.
+> - If `DATAHUB_MCP_AUTH_TOKENS` is not set the server starts without authentication and logs a warning when using an HTTP transport.
+> - Tokens should be injected at runtime via a secret manager (Kubernetes Secrets, Vault, etc.) rather than committed to configuration files.
+> - To generate a cryptographically random token: `python -c "import secrets; print(secrets.token_urlsafe(32))"`
 
 ## Example: Data Discovery & Understanding Flow (for Agents Using DataHub Tools)
 

--- a/src/mcp_server_datahub/__main__.py
+++ b/src/mcp_server_datahub/__main__.py
@@ -14,6 +14,7 @@ from typing_extensions import Literal
 
 from mcp_server_datahub._telemetry import TelemetryMiddleware
 from mcp_server_datahub._version import __version__
+from mcp_server_datahub.auth import DATAHUB_MCP_AUTH_TOKENS_ENV_VAR, build_auth_provider
 from mcp_server_datahub.document_tools_middleware import DocumentToolsMiddleware
 from mcp_server_datahub.mcp_server import mcp, register_all_tools, with_datahub_client
 from mcp_server_datahub.version_requirements import VersionFilterMiddleware
@@ -77,6 +78,13 @@ def create_app() -> FastMCP:
         datahub_component=f"mcp-server-datahub/{__version__}",
     )
 
+    # Configure authentication if tokens are provided.  Auth is applied at
+    # the HTTP layer (FastMCP installs AuthenticationMiddleware when mcp.auth
+    # is set), so it has no effect on stdio transport.
+    auth = build_auth_provider()
+    if auth is not None:
+        mcp.auth = auth
+
     # _DataHubClientMiddleware must be first so the client ContextVar is
     # available to all subsequent middlewares and tool handlers.  This is
     # especially important for HTTP transport where each request runs in a
@@ -113,6 +121,14 @@ def main(transport: Literal["stdio", "sse", "http"], debug: bool) -> None:
         mcp.add_middleware(LoggingMiddleware(include_payloads=True))
 
     create_app()
+
+    if transport in ("http", "sse") and mcp.auth is None:
+        logging.warning(
+            "DataHub MCP server is running with HTTP transport but no authentication "
+            "is configured. Set the %s environment variable to a comma-separated list "
+            "of bearer tokens to secure the server.",
+            DATAHUB_MCP_AUTH_TOKENS_ENV_VAR,
+        )
 
     if transport == "http":
         mcp.run(transport=transport, show_banner=False, stateless_http=True)

--- a/src/mcp_server_datahub/auth.py
+++ b/src/mcp_server_datahub/auth.py
@@ -1,0 +1,118 @@
+"""Static-token authentication provider for the DataHub MCP server.
+
+This module provides a simple shared-key authentication mechanism for
+self-hosted deployments of the DataHub MCP server. It is intentionally
+minimal: no OAuth, no JWTs, no key-management service required.
+
+Configuration
+-------------
+Set the ``DATAHUB_MCP_AUTH_TOKENS`` environment variable to a
+comma-separated list of opaque tokens before starting the server::
+
+    export DATAHUB_MCP_AUTH_TOKENS="token-abc123,token-xyz789"
+
+Clients authenticate by sending the token as a standard HTTP Bearer
+credential::
+
+    Authorization: Bearer token-abc123
+
+Multiple tokens are supported so that keys can be rotated without
+downtime — issue a new token, distribute it, then remove the old one.
+
+Transport behaviour
+-------------------
+Authentication is enforced **only for HTTP-based transports** (``sse``
+and ``http``).  The ``stdio`` transport runs as a subprocess of the MCP
+client and has no network exposure, so auth is neither needed nor
+possible there.
+
+If ``DATAHUB_MCP_AUTH_TOKENS`` is not set the auth provider is not
+installed and the server remains open (same behaviour as before).  A
+warning is logged when running with an HTTP transport without auth so
+operators are aware of the exposure.
+
+Security notes
+--------------
+- Tokens are compared with :func:`secrets.compare_digest` to avoid
+  timing-based side-channel attacks.
+- Tokens should be treated as secrets: use a secret manager or
+  environment-variable injection (e.g. Kubernetes Secrets, Vault) rather
+  than hard-coding them in config files.
+- There is no built-in expiry; rotate tokens by updating the env var and
+  restarting (or hot-reloading) the server.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Optional
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+from loguru import logger
+
+# Environment variable that holds the comma-separated list of valid tokens.
+DATAHUB_MCP_AUTH_TOKENS_ENV_VAR = "DATAHUB_MCP_AUTH_TOKENS"
+
+
+class StaticTokenAuthProvider(TokenVerifier):
+    """Authenticates requests against a fixed set of pre-shared tokens.
+
+    Each incoming ``Authorization: Bearer <token>`` header value is
+    checked against the configured token set using a constant-time
+    comparison.  If the token matches any entry the request is accepted;
+    otherwise a 401 is returned by FastMCP's authentication middleware.
+
+    Parameters
+    ----------
+    tokens:
+        Non-empty list of valid opaque token strings.  Leading/trailing
+        whitespace is stripped from each entry.
+    """
+
+    def __init__(self, tokens: list[str]) -> None:
+        super().__init__()
+        cleaned = [t.strip() for t in tokens if t.strip()]
+        if not cleaned:
+            raise ValueError(
+                "StaticTokenAuthProvider requires at least one non-empty token. "
+                f"Check the {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR} environment variable."
+            )
+        # frozenset for O(1) membership, but we still iterate to use
+        # compare_digest — a frozenset.__contains__ check would be
+        # susceptible to early-exit timing differences.
+        self._tokens: tuple[bytes, ...] = tuple(t.encode("utf-8") for t in cleaned)
+        logger.info(
+            "DataHub MCP auth enabled — {} token(s) configured.",
+            len(self._tokens),
+        )
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        """Return an :class:`AccessToken` if *token* is valid, else ``None``."""
+        token_bytes = token.encode("utf-8")
+        for valid in self._tokens:
+            if secrets.compare_digest(token_bytes, valid):
+                return AccessToken(
+                    token=token,
+                    # Use a generic client ID — we don't issue per-client tokens.
+                    client_id="mcp-client",
+                    scopes=[],
+                )
+        return None
+
+
+def build_auth_provider() -> Optional[StaticTokenAuthProvider]:
+    """Build a :class:`StaticTokenAuthProvider` from environment variables.
+
+    Reads :data:`DATAHUB_MCP_AUTH_TOKENS_ENV_VAR`, splits on commas and
+    returns a configured provider.  Returns ``None`` when the variable is
+    absent or empty so callers can treat *no auth* as a valid (if
+    discouraged) configuration.
+    """
+    raw = os.environ.get(DATAHUB_MCP_AUTH_TOKENS_ENV_VAR, "").strip()
+    if not raw:
+        return None
+    tokens = [t.strip() for t in raw.split(",") if t.strip()]
+    if not tokens:
+        return None
+    return StaticTokenAuthProvider(tokens)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,12 @@ if using_oss:
     mcp_module._token_estimator = _token_estimator  # type: ignore[attr-defined]
     sys.modules["datahub_integrations.mcp._token_estimator"] = _token_estimator
 
+    # Import and expose auth
+    from mcp_server_datahub import auth
+
+    mcp_module.auth = auth  # type: ignore[attr-defined]
+    sys.modules["datahub_integrations.mcp.auth"] = auth
+
     # Create datahub_integrations.mcp.tools submodule
     tools_module = types.ModuleType("datahub_integrations.mcp.tools")
     sys.modules["datahub_integrations.mcp.tools"] = tools_module

--- a/tests/test_mcp/test_auth.py
+++ b/tests/test_mcp/test_auth.py
@@ -1,0 +1,154 @@
+"""
+Tests for the static-token authentication provider.
+
+Test scenarios:
+1. build_auth_provider returns None when env var is absent
+2. build_auth_provider returns None when env var is empty / whitespace-only
+3. build_auth_provider returns None when all comma-separated entries are blank
+4. build_auth_provider returns a provider with the correct token count
+5. Whitespace around token entries is stripped
+6. StaticTokenAuthProvider raises ValueError on empty token list
+7. verify_token returns AccessToken for a valid token
+8. verify_token returns None for an invalid token
+9. All configured tokens are accepted (multi-token rotation support)
+10. Timing-safe comparison is used (secrets.compare_digest)
+"""
+
+import secrets
+from unittest.mock import patch
+
+import pytest
+
+from datahub_integrations.mcp.auth import (
+    DATAHUB_MCP_AUTH_TOKENS_ENV_VAR,
+    StaticTokenAuthProvider,
+    build_auth_provider,
+)
+
+
+class TestBuildAuthProvider:
+    """Tests for the build_auth_provider factory function."""
+
+    def test_returns_none_when_env_var_absent(self):
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure the variable is not set
+            import os
+
+            os.environ.pop(DATAHUB_MCP_AUTH_TOKENS_ENV_VAR, None)
+            assert build_auth_provider() is None
+
+    def test_returns_none_when_env_var_empty(self):
+        with patch.dict("os.environ", {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: ""}):
+            assert build_auth_provider() is None
+
+    def test_returns_none_when_env_var_whitespace_only(self):
+        with patch.dict("os.environ", {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: "   "}):
+            assert build_auth_provider() is None
+
+    def test_returns_none_when_all_entries_blank(self):
+        with patch.dict("os.environ", {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: " , , "}):
+            assert build_auth_provider() is None
+
+    def test_returns_provider_for_single_token(self):
+        with patch.dict(
+            "os.environ", {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: "my-secret-token"}
+        ):
+            provider = build_auth_provider()
+            assert provider is not None
+            assert isinstance(provider, StaticTokenAuthProvider)
+
+    def test_returns_provider_for_multiple_tokens(self):
+        with patch.dict(
+            "os.environ",
+            {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: "token-a,token-b,token-c"},
+        ):
+            provider = build_auth_provider()
+            assert provider is not None
+            assert len(provider._tokens) == 3
+
+    def test_whitespace_around_tokens_is_stripped(self):
+        with patch.dict(
+            "os.environ",
+            {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: "  token-a , token-b  "},
+        ):
+            provider = build_auth_provider()
+            assert provider is not None
+            # Tokens should be stored as stripped bytes
+            assert b"token-a" in provider._tokens
+            assert b"token-b" in provider._tokens
+
+    def test_blank_entries_among_valid_tokens_are_ignored(self):
+        with patch.dict(
+            "os.environ",
+            {DATAHUB_MCP_AUTH_TOKENS_ENV_VAR: "token-a,,token-b,"},
+        ):
+            provider = build_auth_provider()
+            assert provider is not None
+            assert len(provider._tokens) == 2
+
+
+class TestStaticTokenAuthProvider:
+    """Tests for StaticTokenAuthProvider.verify_token."""
+
+    def test_raises_on_empty_token_list(self):
+        with pytest.raises(ValueError, match="at least one"):
+            StaticTokenAuthProvider([])
+
+    def test_raises_on_all_blank_tokens(self):
+        with pytest.raises(ValueError, match="at least one"):
+            StaticTokenAuthProvider(["", "  "])
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_access_token(self):
+        provider = StaticTokenAuthProvider(["correct-token"])
+        result = await provider.verify_token("correct-token")
+        assert result is not None
+        assert result.token == "correct-token"
+        assert result.client_id == "mcp-client"
+        assert result.scopes == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_none(self):
+        provider = StaticTokenAuthProvider(["correct-token"])
+        result = await provider.verify_token("wrong-token")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_string_token_returns_none(self):
+        provider = StaticTokenAuthProvider(["correct-token"])
+        result = await provider.verify_token("")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_all_configured_tokens_are_accepted(self):
+        tokens = ["token-alpha", "token-beta", "token-gamma"]
+        provider = StaticTokenAuthProvider(tokens)
+        for token in tokens:
+            result = await provider.verify_token(token)
+            assert result is not None, f"Token '{token}' should be accepted"
+
+    @pytest.mark.asyncio
+    async def test_only_configured_tokens_are_accepted(self):
+        provider = StaticTokenAuthProvider(["valid"])
+        assert await provider.verify_token("invalid") is None
+        assert await provider.verify_token("VALID") is None  # case-sensitive
+        assert await provider.verify_token("valid ") is None  # trailing space
+
+    @pytest.mark.asyncio
+    async def test_comparison_uses_secrets_compare_digest(self):
+        """Verify we delegate to secrets.compare_digest (timing-safe)."""
+        provider = StaticTokenAuthProvider(["my-token"])
+        with patch("mcp_server_datahub.auth.secrets.compare_digest") as mock_digest:
+            mock_digest.return_value = True
+            result = await provider.verify_token("my-token")
+            assert mock_digest.called
+            assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_cryptographically_random_token_is_accepted(self):
+        """End-to-end: generate a real random token and verify it round-trips."""
+        token = secrets.token_urlsafe(32)
+        provider = StaticTokenAuthProvider([token])
+        result = await provider.verify_token(token)
+        assert result is not None
+        assert result.token == token


### PR DESCRIPTION
## Add bearer-token authentication for HTTP/SSE transports

### Problem

When running the DataHub MCP server over HTTP or SSE transport as a shared, network-accessible service, the server accepted connections from anyone with network access — there was no authentication layer between clients and the MCP endpoint.

There is an open issue regarding this: https://github.com/acryldata/mcp-server-datahub/issues/86

### Solution

Adds a lightweight static-token authentication provider that validates incoming `Authorization: Bearer <token>` headers against a configurable list of pre-shared tokens. This uses FastMCP's built-in `TokenVerifier` / `AuthenticationMiddleware` integration so the enforcement is at the HTTP layer before any MCP message processing occurs.

### How it works

Set `DATAHUB_MCP_AUTH_TOKENS` to a comma-separated list of opaque tokens before starting the server:

```bash
export DATAHUB_MCP_AUTH_TOKENS="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
```

Clients authenticate with a standard Bearer header:

```
Authorization: Bearer <token>
```

Multiple tokens are supported to allow zero-downtime rotation — distribute a new token, then remove the old one.

### Changes

- **`src/mcp_server_datahub/auth.py`** _(new)_ — `StaticTokenAuthProvider` (extends FastMCP's `TokenVerifier`) and `build_auth_provider()` factory that reads from the env var.
- **`src/mcp_server_datahub/__main__.py`** — `create_app()` installs the auth provider when the env var is set; `main()` logs a warning when running HTTP/SSE without auth configured.
- **`tests/test_mcp/test_auth.py`** _(new)_ — 17 unit tests covering token parsing, whitespace handling, valid/invalid verification, rotation, and timing-safe comparison.
- **`tests/conftest.py`** — registers `auth` module in the cross-repo compatibility shim.
- **`README.md`** — new [Server Authentication](#server-authentication) section with setup instructions and opencode config example.
- **`CLAUDE.md`** — updated Authentication section to document both backend and client-facing auth.

### Security notes

- Tokens are compared with `secrets.compare_digest` to prevent timing side-channel attacks.
- Auth is **only enforced for HTTP and SSE transports**. The `stdio` transport runs as a local subprocess with no network exposure and is unaffected.
- If `DATAHUB_MCP_AUTH_TOKENS` is unset the server behaves as before (open), and a warning is logged when an HTTP transport is used without auth.
- Token values should be injected at runtime via a secret manager (Kubernetes Secrets, Vault, etc.) rather than committed to config files.
