### PR TITLE
feat(tools): add Data Product create/update/delete and asset attach/detach tools

### DIFF
--- a/scripts/smoke_check.py
+++ b/scripts/smoke_check.py
@@ -580,6 +580,7 @@ async def check_set_remove_domains(
 
 @check(
     "create_data_product",
+    "update_data_product",
     "add_assets_to_data_product",
     "remove_assets_from_data_product",
     "delete_data_product",
@@ -588,18 +589,49 @@ async def check_set_remove_domains(
 async def check_data_product_lifecycle(
     c: Client, report: SmokeCheckReport, urns: DiscoveredURNs
 ) -> None:
-    create_result = await call_tool(
-        c,
-        "create_data_product",
-        {
-            "name": "[Smoke Check] Test Data Product",
-            "domain_urn": urns.domain_urn,
-            "description": "Created by the MCP smoke check. Safe to delete.",
-        },
-    )
-    create_data = json.loads(create_result.content[0].text)
-    dp_urn = create_data.get("urn", "")
+    downstream_tools = [
+        "update_data_product",
+        "add_assets_to_data_product",
+        "remove_assets_from_data_product",
+        "delete_data_product",
+    ]
+
+    try:
+        create_result = await call_tool(
+            c,
+            "create_data_product",
+            {
+                "name": "[Smoke Check] Test Data Product",
+                "domain_urn": urns.domain_urn,
+                "description": "Created by the MCP smoke check. Safe to delete.",
+            },
+        )
+        create_data = json.loads(create_result.content[0].text)
+        dp_urn = create_data.get("urn", "")
+        if not dp_urn:
+            raise RuntimeError(
+                f"create_data_product succeeded but returned no urn: {create_data}"
+            )
+    except Exception as e:
+        report.record("create_data_product", False, error=str(e))
+        for tool in downstream_tools:
+            report.record(tool, False, error="Skipped: create_data_product failed")
+        return
+
     report.record("create_data_product", True, f"Created: {dp_urn}")
+
+    try:
+        await call_tool(
+            c,
+            "update_data_product",
+            {
+                "data_product_urn": dp_urn,
+                "description": "Updated by the MCP smoke check.",
+            },
+        )
+        report.record("update_data_product", True, f"Updated {dp_urn}")
+    except Exception as e:
+        report.record("update_data_product", False, error=str(e))
 
     try:
         await call_tool(

--- a/scripts/smoke_check.py
+++ b/scripts/smoke_check.py
@@ -579,6 +579,58 @@ async def check_set_remove_domains(
 
 
 @check(
+    "create_data_product",
+    "add_assets_to_data_product",
+    "remove_assets_from_data_product",
+    "delete_data_product",
+    urns=["dataset_urn", "domain_urn"],
+)
+async def check_data_product_lifecycle(
+    c: Client, report: SmokeCheckReport, urns: DiscoveredURNs
+) -> None:
+    create_result = await call_tool(
+        c,
+        "create_data_product",
+        {
+            "name": "[Smoke Check] Test Data Product",
+            "domain_urn": urns.domain_urn,
+            "description": "Created by the MCP smoke check. Safe to delete.",
+        },
+    )
+    create_data = json.loads(create_result.content[0].text)
+    dp_urn = create_data.get("urn", "")
+    report.record("create_data_product", True, f"Created: {dp_urn}")
+
+    try:
+        await call_tool(
+            c,
+            "add_assets_to_data_product",
+            {"data_product_urn": dp_urn, "entity_urns": [urns.dataset_urn]},
+        )
+        report.record("add_assets_to_data_product", True, f"Added {urns.dataset_urn}")
+    except Exception as e:
+        report.record("add_assets_to_data_product", False, error=str(e))
+
+    try:
+        await call_tool(
+            c,
+            "remove_assets_from_data_product",
+            {"data_product_urn": dp_urn, "entity_urns": [urns.dataset_urn]},
+        )
+        report.record(
+            "remove_assets_from_data_product", True, f"Removed {urns.dataset_urn}"
+        )
+    except Exception as e:
+        report.record("remove_assets_from_data_product", False, error=str(e))
+
+    try:
+        await call_tool(c, "delete_data_product", {"data_product_urn": dp_urn})
+        report.record("delete_data_product", True, f"Deleted {dp_urn}")
+    except Exception as e:
+        report.record("delete_data_product", False, error=str(e))
+
+
+@check(
     "add_structured_properties",
     "remove_structured_properties",
     urns=["dataset_urn", "structured_property_urn"],

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -65,6 +65,13 @@ from .graphql_helpers import (  # noqa: F401 (re-exported for backward compat)
 )
 from .search_filter_parser import FILTER_DOCS
 from .tools.assertions import get_dataset_assertions
+from .tools.data_products import (
+    add_assets_to_data_product,
+    create_data_product,
+    delete_data_product,
+    remove_assets_from_data_product,
+    update_data_product,
+)
 from .tools.dataset_queries import get_dataset_queries
 from .tools.descriptions import update_description
 from .tools.documents import grep_documents, search_documents
@@ -256,6 +263,36 @@ def register_mutation_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None
     )
     _register_tool(
         mcp_instance, "remove_domains", remove_domains, tags={ToolType.MUTATION.value}
+    )
+    _register_tool(
+        mcp_instance,
+        "create_data_product",
+        create_data_product,
+        tags={ToolType.MUTATION.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "update_data_product",
+        update_data_product,
+        tags={ToolType.MUTATION.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "delete_data_product",
+        delete_data_product,
+        tags={ToolType.MUTATION.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "add_assets_to_data_product",
+        add_assets_to_data_product,
+        tags={ToolType.MUTATION.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "remove_assets_from_data_product",
+        remove_assets_from_data_product,
+        tags={ToolType.MUTATION.value},
     )
     _register_tool(mcp_instance, "update_description", update_description)
     _register_tool(mcp_instance, "add_structured_properties", add_structured_properties)

--- a/src/mcp_server_datahub/tools/__init__.py
+++ b/src/mcp_server_datahub/tools/__init__.py
@@ -1,5 +1,12 @@
 """MCP tools for DataHub integrations."""
 
+from .data_products import (
+    add_assets_to_data_product,
+    create_data_product,
+    delete_data_product,
+    remove_assets_from_data_product,
+    update_data_product,
+)
 from .dataset_queries import get_dataset_queries
 from .descriptions import update_description
 from .documents import grep_documents, search_documents
@@ -20,10 +27,13 @@ from .terms import (
 )
 
 __all__ = [
+    "add_assets_to_data_product",
     "add_glossary_terms",
     "add_owners",
     "add_structured_properties",
     "add_tags",
+    "create_data_product",
+    "delete_data_product",
     "enhanced_search",
     "get_dataset_queries",
     "get_entities",
@@ -32,6 +42,7 @@ __all__ = [
     "get_me",
     "grep_documents",
     "list_schema_fields",
+    "remove_assets_from_data_product",
     "remove_domains",
     "remove_glossary_terms",
     "remove_owners",
@@ -40,5 +51,6 @@ __all__ = [
     "search",
     "search_documents",
     "set_domains",
+    "update_data_product",
     "update_description",
 ]

--- a/src/mcp_server_datahub/tools/data_products.py
+++ b/src/mcp_server_datahub/tools/data_products.py
@@ -64,6 +64,23 @@ def _validate_domain_urn(client: DataHubClient, domain_urn: str) -> None:
         raise ValueError(f"Failed to validate domain URN: {str(e)}") from e
 
 
+def _check_data_product_entity(entity: Optional[dict], data_product_urn: str) -> None:
+    """Raise ValueError if `entity` (the result of an `entity(urn: ...)` lookup)
+    is not a valid, existing Data Product."""
+    if entity is None:
+        raise ValueError(
+            f"Data Product URN does not exist in DataHub: {data_product_urn}. "
+            f"Please use the search tool with entity_type filter to find existing data "
+            f"products, or create it first with create_data_product."
+        )
+
+    if entity.get("type") != "DATA_PRODUCT":
+        raise ValueError(
+            f"The URN is not a Data Product entity: {data_product_urn} "
+            f"(type: {entity.get('type')})"
+        )
+
+
 def _validate_data_product_urn(client: DataHubClient, data_product_urn: str) -> None:
     """
     Validate that the Data Product URN exists in DataHub.
@@ -93,20 +110,7 @@ def _validate_data_product_urn(client: DataHubClient, data_product_urn: str) -> 
             operation_name="getDataProduct",
         )
 
-        entity = result.get("entity")
-
-        if entity is None:
-            raise ValueError(
-                f"Data Product URN does not exist in DataHub: {data_product_urn}. "
-                f"Please use the search tool with entity_type filter to find existing data "
-                f"products, or create it first with create_data_product."
-            )
-
-        if entity.get("type") != "DATA_PRODUCT":
-            raise ValueError(
-                f"The URN is not a Data Product entity: {data_product_urn} "
-                f"(type: {entity.get('type')})"
-            )
+        _check_data_product_entity(result.get("entity"), data_product_urn)
 
     except Exception as e:
         if isinstance(e, ValueError):
@@ -122,6 +126,11 @@ def _multiple_data_products_per_asset_enabled(client: DataHubClient) -> bool:
     supports, so it's tagged #[NEWER_GMS] and this helper fails closed to False on
     any error (older server, field not present, etc.) — callers then use the
     always-available single-Data-Product-per-asset mutation instead.
+
+    This is intentionally a separate GraphQL call from Data Product URN validation
+    (rather than combined into one query) so that a transient failure here can
+    fail closed without also blocking validation, which must succeed for the
+    calling mutation to proceed at all.
     """
     graph_id = id(client._graph)
     if graph_id in _multiple_dp_feature_flag_cache:
@@ -158,6 +167,131 @@ def _multiple_data_products_per_asset_enabled(client: DataHubClient) -> bool:
 
     _multiple_dp_feature_flag_cache[graph_id] = enabled
     return enabled
+
+
+def _get_current_data_product_urns(
+    client: DataHubClient, entity_urns: List[str]
+) -> dict:
+    """Look up which Data Product, if any, each of the given entities is currently
+    associated with, via the generic DataProductContains incoming relationship
+    defined on the Entity interface.
+
+    Returns a mapping of entity_urn -> its current Data Product urn, or None if
+    the entity has no Data Product association.
+    """
+    var_names = [f"urn{i}" for i in range(len(entity_urns))]
+    var_decls = ", ".join(f"${name}: String!" for name in var_names)
+    fields = "\n".join(
+        f"""
+        e{i}: entity(urn: ${var_names[i]}) {{
+            relationships(
+                input: {{
+                    types: ["DataProductContains"]
+                    direction: INCOMING
+                    start: 0
+                    count: 1
+                }}
+            ) {{
+                relationships {{
+                    entity {{
+                        urn
+                    }}
+                }}
+            }}
+        }}
+        """
+        for i in range(len(entity_urns))
+    )
+    query = f"query getCurrentDataProducts({var_decls}) {{ {fields} }}"
+    variables = dict(zip(var_names, entity_urns))
+
+    result = graphql_helpers.execute_graphql(
+        client._graph,
+        query=query,
+        variables=variables,
+        operation_name="getCurrentDataProducts",
+    )
+
+    membership: dict = {}
+    for i, entity_urn in enumerate(entity_urns):
+        entity_result = result.get(f"e{i}") or {}
+        relationships = (entity_result.get("relationships") or {}).get(
+            "relationships"
+        ) or []
+        membership[entity_urn] = (
+            relationships[0]["entity"]["urn"] if relationships else None
+        )
+    return membership
+
+
+def _execute_bool_mutation(
+    client: DataHubClient,
+    *,
+    query: str,
+    variables: dict,
+    operation_name: str,
+    success_message: str,
+    failure_message: str,
+    error_prefix: str,
+) -> dict:
+    """Execute a GraphQL mutation that returns a plain boolean success flag, and
+    translate the result into this module's standard {success, message} shape.
+
+    Raises:
+        RuntimeError: If the mutation call raises, or returns a falsy result.
+    """
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=query,
+            variables=variables,
+            operation_name=operation_name,
+        )
+
+        if result.get(operation_name, False):
+            return {"success": True, "message": success_message}
+        else:
+            raise RuntimeError(failure_message)
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"{error_prefix}: {str(e)}") from e
+
+
+def _execute_urn_mutation(
+    client: DataHubClient,
+    *,
+    query: str,
+    variables: dict,
+    operation_name: str,
+    failure_message: str,
+    error_prefix: str,
+) -> dict:
+    """Execute a GraphQL mutation that returns an object with a `urn` field
+    (e.g. createDataProduct, updateDataProduct), and return that object.
+
+    Raises:
+        RuntimeError: If the mutation call raises, or returns no urn.
+    """
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=query,
+            variables=variables,
+            operation_name=operation_name,
+        )
+
+        payload = result.get(operation_name)
+        if payload and payload.get("urn"):
+            return payload
+        else:
+            raise RuntimeError(failure_message)
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"{error_prefix}: {str(e)}") from e
 
 
 @min_version(cloud="0.3.16", oss="1.4.0")
@@ -231,30 +365,20 @@ def create_data_product(
         }
     """
 
-    try:
-        result = graphql_helpers.execute_graphql(
-            client._graph,
-            query=mutation,
-            variables={"input": input_data},
-            operation_name="createDataProduct",
-        )
+    created = _execute_urn_mutation(
+        client,
+        query=mutation,
+        variables={"input": input_data},
+        operation_name="createDataProduct",
+        failure_message="Failed to create Data Product - mutation returned no urn",
+        error_prefix="Error creating Data Product",
+    )
 
-        created = result.get("createDataProduct")
-        if created and created.get("urn"):
-            return {
-                "success": True,
-                "urn": created["urn"],
-                "message": f"Successfully created Data Product '{name}' ({created['urn']})",
-            }
-        else:
-            raise RuntimeError(
-                "Failed to create Data Product - mutation returned no urn"
-            )
-
-    except Exception as e:
-        if isinstance(e, RuntimeError):
-            raise
-        raise RuntimeError(f"Error creating Data Product: {str(e)}") from e
+    return {
+        "success": True,
+        "urn": created["urn"],
+        "message": f"Successfully created Data Product '{name}' ({created['urn']})",
+    }
 
 
 @min_version(cloud="0.3.16", oss="1.4.0")
@@ -294,6 +418,8 @@ def update_data_product(
         raise ValueError("data_product_urn cannot be empty")
     if name is None and description is None:
         raise ValueError("At least one of name or description must be provided")
+    if name is not None and not name.strip():
+        raise ValueError("name cannot be empty")
 
     _validate_data_product_urn(client, data_product_urn)
 
@@ -311,28 +437,19 @@ def update_data_product(
         }
     """
 
-    try:
-        result = graphql_helpers.execute_graphql(
-            client._graph,
-            query=mutation,
-            variables={"urn": data_product_urn, "input": input_data},
-            operation_name="updateDataProduct",
-        )
+    _execute_urn_mutation(
+        client,
+        query=mutation,
+        variables={"urn": data_product_urn, "input": input_data},
+        operation_name="updateDataProduct",
+        failure_message="Failed to update Data Product - mutation returned no urn",
+        error_prefix="Error updating Data Product",
+    )
 
-        if (result.get("updateDataProduct") or {}).get("urn"):
-            return {
-                "success": True,
-                "message": f"Successfully updated Data Product {data_product_urn}",
-            }
-        else:
-            raise RuntimeError(
-                "Failed to update Data Product - mutation returned no urn"
-            )
-
-    except Exception as e:
-        if isinstance(e, RuntimeError):
-            raise
-        raise RuntimeError(f"Error updating Data Product: {str(e)}") from e
+    return {
+        "success": True,
+        "message": f"Successfully updated Data Product {data_product_urn}",
+    }
 
 
 @min_version(cloud="0.3.16", oss="1.4.0")
@@ -366,28 +483,15 @@ def delete_data_product(data_product_urn: str) -> dict:
         }
     """
 
-    try:
-        result = graphql_helpers.execute_graphql(
-            client._graph,
-            query=mutation,
-            variables={"urn": data_product_urn},
-            operation_name="deleteDataProduct",
-        )
-
-        if result.get("deleteDataProduct", False):
-            return {
-                "success": True,
-                "message": f"Successfully deleted Data Product {data_product_urn}",
-            }
-        else:
-            raise RuntimeError(
-                "Failed to delete Data Product - operation returned false"
-            )
-
-    except Exception as e:
-        if isinstance(e, RuntimeError):
-            raise
-        raise RuntimeError(f"Error deleting Data Product: {str(e)}") from e
+    return _execute_bool_mutation(
+        client,
+        query=mutation,
+        variables={"urn": data_product_urn},
+        operation_name="deleteDataProduct",
+        success_message=f"Successfully deleted Data Product {data_product_urn}",
+        failure_message="Failed to delete Data Product - operation returned false",
+        error_prefix="Error deleting Data Product",
+    )
 
 
 @min_version(cloud="0.3.16", oss="1.4.0")
@@ -463,31 +567,20 @@ def add_assets_to_data_product(
         operation_name = "batchSetDataProduct"
         mode_message = "set on (replacing any prior Data Product assignment for)"
 
-    try:
-        result = graphql_helpers.execute_graphql(
-            client._graph,
-            query=mutation,
-            variables=variables,
-            operation_name=operation_name,
-        )
-
-        if result.get(operation_name, False):
-            return {
-                "success": True,
-                "message": (
-                    f"Successfully {mode_message} {len(entity_urns)} asset(s) "
-                    f"for Data Product {data_product_urn}"
-                ),
-            }
-        else:
-            raise RuntimeError(
-                f"Failed to add assets to Data Product - {operation_name} returned false"
-            )
-
-    except Exception as e:
-        if isinstance(e, RuntimeError):
-            raise
-        raise RuntimeError(f"Error adding assets to Data Product: {str(e)}") from e
+    return _execute_bool_mutation(
+        client,
+        query=mutation,
+        variables=variables,
+        operation_name=operation_name,
+        success_message=(
+            f"Successfully {mode_message} {len(entity_urns)} asset(s) "
+            f"for Data Product {data_product_urn}"
+        ),
+        failure_message=(
+            f"Failed to add assets to Data Product - {operation_name} returned false"
+        ),
+        error_prefix="Error adding assets to Data Product",
+    )
 
 
 @min_version(cloud="0.3.16", oss="1.4.0")
@@ -497,6 +590,16 @@ def remove_assets_from_data_product(
 ) -> dict:
     """Detach one or more data assets from a Data Product.
 
+    Note: DataHub instances may allow either multiple Data Products per asset, or
+    only one at a time, depending on server configuration.
+    - If multiple Data Products per asset are allowed, only this asset's
+      association with THIS Data Product is removed; any other Data Products it
+      belongs to are left untouched.
+    - Otherwise, each asset can have at most one Data Product at a time. This
+      tool only detaches assets that are currently assigned to THIS Data
+      Product; assets that are not currently assigned to it are left unchanged
+      and reported as skipped in the response message.
+
     Args:
         data_product_urn: URN of the Data Product to detach assets from
         entity_urns: List of asset URNs to detach (e.g., dataset URNs, dashboard URNs)
@@ -504,7 +607,8 @@ def remove_assets_from_data_product(
     Returns:
         Dictionary with:
         - success: Boolean indicating if the operation succeeded
-        - message: Success or error message
+        - message: Success or error message, noting any assets that were
+                   skipped because they weren't assigned to this Data Product
 
     Examples:
         remove_assets_from_data_product(
@@ -523,6 +627,8 @@ def remove_assets_from_data_product(
 
     _validate_data_product_urn(client, data_product_urn)
 
+    skipped_urns: List[str] = []
+
     if _multiple_data_products_per_asset_enabled(client):
         mutation = """
             mutation batchRemoveFromDataProducts($input: BatchSetDataProductsInput!) {
@@ -536,7 +642,32 @@ def remove_assets_from_data_product(
             }
         }
         operation_name = "batchRemoveFromDataProducts"
+        target_urns = entity_urns
     else:
+        # Each asset can only have at most one Data Product in this mode, and the
+        # only mutation available to unset it (batchSetDataProduct with a null
+        # dataProductUrn) clears WHATEVER Data Product is currently set, with no
+        # regard for which urn was requested. So we must check current membership
+        # ourselves first, and only unset assets that actually belong to this
+        # Data Product, otherwise we'd risk silently detaching an asset from a
+        # different Data Product than the one the caller asked about.
+        current_membership = _get_current_data_product_urns(client, entity_urns)
+        target_urns = [
+            urn
+            for urn in entity_urns
+            if current_membership.get(urn) == data_product_urn
+        ]
+        skipped_urns = [urn for urn in entity_urns if urn not in target_urns]
+
+        if not target_urns:
+            return {
+                "success": True,
+                "message": (
+                    f"No assets were removed: none of the given asset(s) are "
+                    f"currently assigned to Data Product {data_product_urn}."
+                ),
+            }
+
         mutation = """
             mutation batchSetDataProduct($input: BatchSetDataProductInput!) {
                 batchSetDataProduct(input: $input)
@@ -545,33 +676,30 @@ def remove_assets_from_data_product(
         variables = {
             "input": {
                 "dataProductUrn": None,
-                "resourceUrns": entity_urns,
+                "resourceUrns": target_urns,
             }
         }
         operation_name = "batchSetDataProduct"
 
-    try:
-        result = graphql_helpers.execute_graphql(
-            client._graph,
-            query=mutation,
-            variables=variables,
-            operation_name=operation_name,
+    result = _execute_bool_mutation(
+        client,
+        query=mutation,
+        variables=variables,
+        operation_name=operation_name,
+        success_message=(
+            f"Successfully removed {len(target_urns)} asset(s) from "
+            f"Data Product {data_product_urn}"
+        ),
+        failure_message=(
+            f"Failed to remove assets from Data Product - {operation_name} returned false"
+        ),
+        error_prefix="Error removing assets from Data Product",
+    )
+
+    if skipped_urns:
+        result["message"] += (
+            f". Skipped {len(skipped_urns)} asset(s) not currently assigned to "
+            f"this Data Product: {', '.join(skipped_urns)}"
         )
 
-        if result.get(operation_name, False):
-            return {
-                "success": True,
-                "message": (
-                    f"Successfully removed {len(entity_urns)} asset(s) from "
-                    f"Data Product {data_product_urn}"
-                ),
-            }
-        else:
-            raise RuntimeError(
-                f"Failed to remove assets from Data Product - {operation_name} returned false"
-            )
-
-    except Exception as e:
-        if isinstance(e, RuntimeError):
-            raise
-        raise RuntimeError(f"Error removing assets from Data Product: {str(e)}") from e
+    return result

--- a/src/mcp_server_datahub/tools/data_products.py
+++ b/src/mcp_server_datahub/tools/data_products.py
@@ -1,0 +1,577 @@
+"""Data Product management tools for DataHub MCP server."""
+
+import logging
+from typing import List, Optional
+
+from datahub.sdk.main_client import DataHubClient
+
+from .. import graphql_helpers
+from ..version_requirements import min_version
+
+logger = logging.getLogger(__name__)
+
+# Cache of whether the connected instance supports assigning multiple Data Products
+# to a single asset, keyed by id(graph). Populated lazily on first use.
+_multiple_dp_feature_flag_cache: dict[int, bool] = {}
+
+
+def _validate_domain_urn(client: DataHubClient, domain_urn: str) -> None:
+    """
+    Validate that the domain URN exists in DataHub.
+
+    Raises:
+        ValueError: If the domain URN does not exist or is invalid
+    """
+    query = """
+        query getDomain($urn: String!) {
+            entity(urn: $urn) {
+                urn
+                type
+                ... on Domain {
+                    properties {
+                        name
+                    }
+                }
+            }
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=query,
+            variables={"urn": domain_urn},
+            operation_name="getDomain",
+        )
+
+        entity = result.get("entity")
+
+        if entity is None:
+            raise ValueError(
+                f"Domain URN does not exist in DataHub: {domain_urn}. "
+                f"Please use the search tool with entity_type filter to find existing domains, "
+                f"or create the domain first before assigning it."
+            )
+
+        if entity.get("type") != "DOMAIN":
+            raise ValueError(
+                f"The URN is not a domain entity: {domain_urn} (type: {entity.get('type')})"
+            )
+
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise ValueError(f"Failed to validate domain URN: {str(e)}") from e
+
+
+def _validate_data_product_urn(client: DataHubClient, data_product_urn: str) -> None:
+    """
+    Validate that the Data Product URN exists in DataHub.
+
+    Raises:
+        ValueError: If the Data Product URN does not exist or is invalid
+    """
+    query = """
+        query getDataProduct($urn: String!) {
+            entity(urn: $urn) {
+                urn
+                type
+                ... on DataProduct {
+                    properties {
+                        name
+                    }
+                }
+            }
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=query,
+            variables={"urn": data_product_urn},
+            operation_name="getDataProduct",
+        )
+
+        entity = result.get("entity")
+
+        if entity is None:
+            raise ValueError(
+                f"Data Product URN does not exist in DataHub: {data_product_urn}. "
+                f"Please use the search tool with entity_type filter to find existing data "
+                f"products, or create it first with create_data_product."
+            )
+
+        if entity.get("type") != "DATA_PRODUCT":
+            raise ValueError(
+                f"The URN is not a Data Product entity: {data_product_urn} "
+                f"(type: {entity.get('type')})"
+            )
+
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise ValueError(f"Failed to validate Data Product URN: {str(e)}") from e
+
+
+def _multiple_data_products_per_asset_enabled(client: DataHubClient) -> bool:
+    """Check whether the connected instance allows assigning multiple Data Products
+    to a single asset (vs. the older one-Data-Product-per-asset model).
+
+    The underlying GraphQL field is newer than the base version this tool otherwise
+    supports, so it's tagged #[NEWER_GMS] and this helper fails closed to False on
+    any error (older server, field not present, etc.) — callers then use the
+    always-available single-Data-Product-per-asset mutation instead.
+    """
+    graph_id = id(client._graph)
+    if graph_id in _multiple_dp_feature_flag_cache:
+        return _multiple_dp_feature_flag_cache[graph_id]
+
+    query = """
+        query getMultipleDataProductsFeatureFlag {
+            appConfig {
+                featureFlags {
+                    multipleDataProductsPerAsset  #[NEWER_GMS]
+                }
+            }
+        }
+    """
+
+    enabled = False
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=query,
+            variables={},
+            operation_name="getMultipleDataProductsFeatureFlag",
+        )
+        enabled = bool(
+            ((result.get("appConfig") or {}).get("featureFlags") or {}).get(
+                "multipleDataProductsPerAsset", False
+            )
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failed to check multipleDataProductsPerAsset feature flag, assuming "
+            f"disabled (will use the single-Data-Product-per-asset mutation): {e}"
+        )
+
+    _multiple_dp_feature_flag_cache[graph_id] = enabled
+    return enabled
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def create_data_product(
+    name: str,
+    domain_urn: str,
+    description: Optional[str] = None,
+    id: Optional[str] = None,
+) -> dict:
+    """Create a new Data Product under a Domain.
+
+    A Data Product groups related data assets (datasets, dashboards, etc.) that
+    together serve a business purpose, under a single ownable, documentable entity.
+
+    Note: The calling user is automatically set as an owner of the new Data Product.
+    Use add_owners/add_tags/add_terms/add_structured_properties afterward to add
+    further metadata. Use add_assets_to_data_product to attach data assets.
+
+    Args:
+        name: Display name for the Data Product (e.g., "Customer 360")
+        domain_urn: URN of the Domain this Data Product belongs to. The domain must
+                   already exist (e.g., "urn:li:domain:marketing")
+        description: Optional description of the Data Product's purpose
+        id: Optional custom identifier for the Data Product. If not provided,
+            DataHub generates one automatically.
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - urn: The URN of the newly created Data Product
+        - message: Success or error message
+
+    Examples:
+        # Create a Data Product under the marketing domain
+        create_data_product(
+            name="Customer 360",
+            domain_urn="urn:li:domain:marketing",
+            description="Unified view of customer data across all touchpoints"
+        )
+
+        # Create a Data Product with a custom id
+        create_data_product(
+            name="Order Analytics",
+            domain_urn="urn:li:domain:sales",
+            description="Aggregated order and fulfillment metrics",
+            id="order-analytics"
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not name or not name.strip():
+        raise ValueError("name cannot be empty")
+    if not domain_urn:
+        raise ValueError("domain_urn cannot be empty")
+
+    _validate_domain_urn(client, domain_urn)
+
+    properties: dict = {"name": name}
+    if description:
+        properties["description"] = description
+
+    input_data: dict = {"properties": properties, "domainUrn": domain_urn}
+    if id:
+        input_data["id"] = id
+
+    mutation = """
+        mutation createDataProduct($input: CreateDataProductInput!) {
+            createDataProduct(input: $input) {
+                urn
+            }
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables={"input": input_data},
+            operation_name="createDataProduct",
+        )
+
+        created = result.get("createDataProduct")
+        if created and created.get("urn"):
+            return {
+                "success": True,
+                "urn": created["urn"],
+                "message": f"Successfully created Data Product '{name}' ({created['urn']})",
+            }
+        else:
+            raise RuntimeError(
+                "Failed to create Data Product - mutation returned no urn"
+            )
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error creating Data Product: {str(e)}") from e
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def update_data_product(
+    data_product_urn: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> dict:
+    """Update the name and/or description of an existing Data Product.
+
+    Args:
+        data_product_urn: URN of the Data Product to update
+        name: New display name for the Data Product. Omit to leave unchanged.
+        description: New description for the Data Product. Omit to leave unchanged.
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - message: Success or error message
+
+    Examples:
+        # Update the description of an existing Data Product
+        update_data_product(
+            data_product_urn="urn:li:dataProduct:customer-360",
+            description="Unified view of customer data across all touchpoints, including support tickets"
+        )
+
+        # Rename a Data Product
+        update_data_product(
+            data_product_urn="urn:li:dataProduct:customer-360",
+            name="Customer 360 (v2)"
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not data_product_urn:
+        raise ValueError("data_product_urn cannot be empty")
+    if name is None and description is None:
+        raise ValueError("At least one of name or description must be provided")
+
+    _validate_data_product_urn(client, data_product_urn)
+
+    input_data: dict = {}
+    if name is not None:
+        input_data["name"] = name
+    if description is not None:
+        input_data["description"] = description
+
+    mutation = """
+        mutation updateDataProduct($urn: String!, $input: UpdateDataProductInput!) {
+            updateDataProduct(urn: $urn, input: $input) {
+                urn
+            }
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables={"urn": data_product_urn, "input": input_data},
+            operation_name="updateDataProduct",
+        )
+
+        if (result.get("updateDataProduct") or {}).get("urn"):
+            return {
+                "success": True,
+                "message": f"Successfully updated Data Product {data_product_urn}",
+            }
+        else:
+            raise RuntimeError(
+                "Failed to update Data Product - mutation returned no urn"
+            )
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error updating Data Product: {str(e)}") from e
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def delete_data_product(data_product_urn: str) -> dict:
+    """Delete a Data Product by URN.
+
+    Note: Assets do not need to be detached first. DataHub asynchronously clears
+    asset associations after the Data Product entity itself is deleted.
+
+    Args:
+        data_product_urn: URN of the Data Product to delete
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - message: Success or error message
+
+    Examples:
+        delete_data_product(data_product_urn="urn:li:dataProduct:customer-360")
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not data_product_urn:
+        raise ValueError("data_product_urn cannot be empty")
+
+    _validate_data_product_urn(client, data_product_urn)
+
+    mutation = """
+        mutation deleteDataProduct($urn: String!) {
+            deleteDataProduct(urn: $urn)
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables={"urn": data_product_urn},
+            operation_name="deleteDataProduct",
+        )
+
+        if result.get("deleteDataProduct", False):
+            return {
+                "success": True,
+                "message": f"Successfully deleted Data Product {data_product_urn}",
+            }
+        else:
+            raise RuntimeError(
+                "Failed to delete Data Product - operation returned false"
+            )
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error deleting Data Product: {str(e)}") from e
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def add_assets_to_data_product(
+    data_product_urn: str,
+    entity_urns: List[str],
+) -> dict:
+    """Attach one or more data assets to a Data Product.
+
+    Note: DataHub instances may allow either multiple Data Products per asset, or
+    only one at a time, depending on server configuration. This tool detects which
+    mode is active:
+    - If multiple Data Products per asset are allowed, assets are added to this
+      Data Product in addition to any others they already belong to.
+    - Otherwise, assigning this Data Product REPLACES any prior Data Product
+      assignment on each asset. The returned message states which mode ran.
+
+    Args:
+        data_product_urn: URN of the Data Product to attach assets to
+        entity_urns: List of asset URNs to attach (e.g., dataset URNs, dashboard URNs)
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - message: Success or error message, noting whether assets were added
+                   additively or replaced any prior Data Product assignment
+
+    Examples:
+        # Attach datasets to a Data Product
+        add_assets_to_data_product(
+            data_product_urn="urn:li:dataProduct:customer-360",
+            entity_urns=[
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)"
+            ]
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not data_product_urn:
+        raise ValueError("data_product_urn cannot be empty")
+    if not entity_urns:
+        raise ValueError("entity_urns cannot be empty")
+
+    _validate_data_product_urn(client, data_product_urn)
+
+    if _multiple_data_products_per_asset_enabled(client):
+        mutation = """
+            mutation batchAddToDataProducts($input: BatchSetDataProductsInput!) {
+                batchAddToDataProducts(input: $input)
+            }
+        """
+        variables: dict = {
+            "input": {
+                "dataProductUrns": [data_product_urn],
+                "resourceUrns": entity_urns,
+            }
+        }
+        operation_name = "batchAddToDataProducts"
+        mode_message = "added to"
+    else:
+        mutation = """
+            mutation batchSetDataProduct($input: BatchSetDataProductInput!) {
+                batchSetDataProduct(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "dataProductUrn": data_product_urn,
+                "resourceUrns": entity_urns,
+            }
+        }
+        operation_name = "batchSetDataProduct"
+        mode_message = "set on (replacing any prior Data Product assignment for)"
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables=variables,
+            operation_name=operation_name,
+        )
+
+        if result.get(operation_name, False):
+            return {
+                "success": True,
+                "message": (
+                    f"Successfully {mode_message} {len(entity_urns)} asset(s) "
+                    f"for Data Product {data_product_urn}"
+                ),
+            }
+        else:
+            raise RuntimeError(
+                f"Failed to add assets to Data Product - {operation_name} returned false"
+            )
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error adding assets to Data Product: {str(e)}") from e
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def remove_assets_from_data_product(
+    data_product_urn: str,
+    entity_urns: List[str],
+) -> dict:
+    """Detach one or more data assets from a Data Product.
+
+    Args:
+        data_product_urn: URN of the Data Product to detach assets from
+        entity_urns: List of asset URNs to detach (e.g., dataset URNs, dashboard URNs)
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - message: Success or error message
+
+    Examples:
+        remove_assets_from_data_product(
+            data_product_urn="urn:li:dataProduct:customer-360",
+            entity_urns=[
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.deprecated_table,PROD)"
+            ]
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not data_product_urn:
+        raise ValueError("data_product_urn cannot be empty")
+    if not entity_urns:
+        raise ValueError("entity_urns cannot be empty")
+
+    _validate_data_product_urn(client, data_product_urn)
+
+    if _multiple_data_products_per_asset_enabled(client):
+        mutation = """
+            mutation batchRemoveFromDataProducts($input: BatchSetDataProductsInput!) {
+                batchRemoveFromDataProducts(input: $input)
+            }
+        """
+        variables: dict = {
+            "input": {
+                "dataProductUrns": [data_product_urn],
+                "resourceUrns": entity_urns,
+            }
+        }
+        operation_name = "batchRemoveFromDataProducts"
+    else:
+        mutation = """
+            mutation batchSetDataProduct($input: BatchSetDataProductInput!) {
+                batchSetDataProduct(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "dataProductUrn": None,
+                "resourceUrns": entity_urns,
+            }
+        }
+        operation_name = "batchSetDataProduct"
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables=variables,
+            operation_name=operation_name,
+        )
+
+        if result.get(operation_name, False):
+            return {
+                "success": True,
+                "message": (
+                    f"Successfully removed {len(entity_urns)} asset(s) from "
+                    f"Data Product {data_product_urn}"
+                ),
+            }
+        else:
+            raise RuntimeError(
+                f"Failed to remove assets from Data Product - {operation_name} returned false"
+            )
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error removing assets from Data Product: {str(e)}") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ if using_oss:
     # The __init__.py re-exports functions which shadows the module names
 
     # Get actual module objects from sys.modules (not the shadowed function refs)
+    data_products_module = sys.modules["mcp_server_datahub.tools.data_products"]
     descriptions_module = sys.modules["mcp_server_datahub.tools.descriptions"]
     documents_module = sys.modules["mcp_server_datahub.tools.documents"]
     domains_module = sys.modules["mcp_server_datahub.tools.domains"]
@@ -133,6 +134,7 @@ if using_oss:
     search_module = sys.modules["mcp_server_datahub.tools.search"]
 
     tools_module.assertions = assertions_module  # type: ignore[attr-defined]
+    tools_module.data_products = data_products_module  # type: ignore[attr-defined]
     tools_module.dataset_queries = dataset_queries_module  # type: ignore[attr-defined]
     tools_module.descriptions = descriptions_module  # type: ignore[attr-defined]
     tools_module.documents = documents_module  # type: ignore[attr-defined]
@@ -148,6 +150,7 @@ if using_oss:
     tools_module.terms = terms_module  # type: ignore[attr-defined]
 
     sys.modules["datahub_integrations.mcp.tools.assertions"] = assertions_module
+    sys.modules["datahub_integrations.mcp.tools.data_products"] = data_products_module
     sys.modules["datahub_integrations.mcp.tools.dataset_queries"] = (
         dataset_queries_module
     )

--- a/tests/test_mcp/tools/test_data_products.py
+++ b/tests/test_mcp/tools/test_data_products.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from datahub_integrations.mcp.tools import data_products as data_products_module
 from datahub_integrations.mcp.tools.data_products import (
     add_assets_to_data_product,
     create_data_product,
@@ -20,6 +21,19 @@ def mock_datahub_client():
     mock_client._graph = MagicMock()
     mock_client._graph.execute_graphql = MagicMock()
     return mock_client
+
+
+@pytest.fixture(autouse=True)
+def clear_feature_flag_cache():
+    """Clear the module-level multiple-Data-Products-per-asset cache before each test.
+
+    The cache is keyed by id(client._graph), and Python can reuse ids of
+    garbage-collected mocks across tests, which would otherwise make results
+    order-dependent.
+    """
+    data_products_module._multiple_dp_feature_flag_cache.clear()
+    yield
+    data_products_module._multiple_dp_feature_flag_cache.clear()
 
 
 # create_data_product tests
@@ -136,6 +150,53 @@ def test_create_data_product_mutation_returns_no_urn(mock_datahub_client):
             create_data_product(name="Customer 360", domain_urn=domain_urn)
 
 
+def test_create_data_product_invalid_domain_type(mock_datahub_client):
+    """Test that a domain_urn pointing at a non-Domain entity returns an error."""
+    domain_urn = "urn:li:tag:not-a-domain"
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {"urn": domain_urn, "type": "TAG"}
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="not a domain entity"):
+            create_data_product(name="Customer 360", domain_urn=domain_urn)
+
+
+def test_create_data_product_validation_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during domain validation."""
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "Connection timeout"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Failed to validate domain URN"):
+            create_data_product(
+                name="Customer 360", domain_urn="urn:li:domain:marketing"
+            )
+
+
+def test_create_data_product_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during the create mutation itself."""
+    domain_urn = "urn:li:domain:marketing"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": domain_urn, "type": "DOMAIN"}},
+        Exception("Network error"),
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Error creating Data Product"):
+            create_data_product(name="Customer 360", domain_urn=domain_urn)
+
+
 # update_data_product tests
 
 
@@ -173,6 +234,16 @@ def test_update_data_product_no_fields_provided(mock_datahub_client):
             update_data_product(data_product_urn="urn:li:dataProduct:customer-360")
 
 
+def test_update_data_product_empty_urn(mock_datahub_client):
+    """Test that empty data_product_urn raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="data_product_urn cannot be empty"):
+            update_data_product(data_product_urn="", name="New Name")
+
+
 def test_update_data_product_nonexistent(mock_datahub_client):
     """Test that a nonexistent Data Product URN returns an error."""
     mock_datahub_client._graph.execute_graphql.return_value = {"entity": None}
@@ -185,6 +256,69 @@ def test_update_data_product_nonexistent(mock_datahub_client):
             update_data_product(
                 data_product_urn="urn:li:dataProduct:nonexistent", name="New Name"
             )
+
+
+def test_update_data_product_invalid_type(mock_datahub_client):
+    """Test that a URN with the wrong entity type returns an error."""
+    dp_urn = "urn:li:tag:not-a-data-product"
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {"urn": dp_urn, "type": "TAG"}
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="not a Data Product entity"):
+            update_data_product(data_product_urn=dp_urn, name="New Name")
+
+
+def test_update_data_product_validation_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during Data Product validation."""
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "Connection timeout"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Failed to validate Data Product URN"):
+            update_data_product(
+                data_product_urn="urn:li:dataProduct:customer-360", name="New Name"
+            )
+
+
+def test_update_data_product_mutation_returns_no_urn(mock_datahub_client):
+    """Test handling when the update mutation returns no urn."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"updateDataProduct": None},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to update Data Product"):
+            update_data_product(data_product_urn=dp_urn, name="New Name")
+
+
+def test_update_data_product_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during the update mutation itself."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        Exception("Network error"),
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Error updating Data Product"):
+            update_data_product(data_product_urn=dp_urn, name="New Name")
 
 
 # delete_data_product tests
@@ -230,6 +364,63 @@ def test_delete_data_product_mutation_returns_false(mock_datahub_client):
         return_value=mock_datahub_client,
     ):
         with pytest.raises(RuntimeError, match="Failed to delete Data Product"):
+            delete_data_product(data_product_urn=dp_urn)
+
+
+def test_delete_data_product_nonexistent(mock_datahub_client):
+    """Test that a nonexistent Data Product URN returns an error."""
+    mock_datahub_client._graph.execute_graphql.return_value = {"entity": None}
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Data Product URN does not exist"):
+            delete_data_product(data_product_urn="urn:li:dataProduct:nonexistent")
+
+
+def test_delete_data_product_invalid_type(mock_datahub_client):
+    """Test that a URN with the wrong entity type returns an error."""
+    dp_urn = "urn:li:tag:not-a-data-product"
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {"urn": dp_urn, "type": "TAG"}
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="not a Data Product entity"):
+            delete_data_product(data_product_urn=dp_urn)
+
+
+def test_delete_data_product_validation_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during Data Product validation."""
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "Connection timeout"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Failed to validate Data Product URN"):
+            delete_data_product(data_product_urn="urn:li:dataProduct:customer-360")
+
+
+def test_delete_data_product_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during the delete mutation itself."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        Exception("Network error"),
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Error deleting Data Product"):
             delete_data_product(data_product_urn=dp_urn)
 
 
@@ -334,6 +525,124 @@ def test_add_assets_empty_entity_urns(mock_datahub_client):
             )
 
 
+def test_add_assets_empty_data_product_urn(mock_datahub_client):
+    """Test that empty data_product_urn raises ValueError."""
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="data_product_urn cannot be empty"):
+            add_assets_to_data_product(data_product_urn="", entity_urns=[dataset_urn])
+
+
+def test_add_assets_nonexistent_data_product(mock_datahub_client):
+    """Test that a nonexistent Data Product URN returns an error."""
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    mock_datahub_client._graph.execute_graphql.return_value = {"entity": None}
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Data Product URN does not exist"):
+            add_assets_to_data_product(
+                data_product_urn="urn:li:dataProduct:nonexistent",
+                entity_urns=[dataset_urn],
+            )
+
+
+def test_add_assets_invalid_data_product_type(mock_datahub_client):
+    """Test that a URN with the wrong entity type returns an error."""
+    dp_urn = "urn:li:tag:not-a-data-product"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {"urn": dp_urn, "type": "TAG"}
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="not a Data Product entity"):
+            add_assets_to_data_product(
+                data_product_urn=dp_urn, entity_urns=[dataset_urn]
+            )
+
+
+def test_add_assets_validation_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during Data Product validation."""
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "Connection timeout"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Failed to validate Data Product URN"):
+            add_assets_to_data_product(
+                data_product_urn="urn:li:dataProduct:customer-360",
+                entity_urns=[dataset_urn],
+            )
+
+
+def test_add_assets_mutation_returns_false(mock_datahub_client):
+    """Test handling when the add-assets mutation returns false."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        {"batchSetDataProduct": False},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to add assets"):
+            add_assets_to_data_product(
+                data_product_urn=dp_urn, entity_urns=[dataset_urn]
+            )
+
+
+def test_add_assets_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during the add-assets mutation itself."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        Exception("Network error"),
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Error adding assets to Data Product"):
+            add_assets_to_data_product(
+                data_product_urn=dp_urn, entity_urns=[dataset_urn]
+            )
+
+
 def test_remove_assets_multiple_dp_per_asset_enabled(mock_datahub_client):
     """When the feature flag is on, assets are removed via batchRemoveFromDataProducts."""
     dp_urn = "urn:li:dataProduct:customer-360"
@@ -406,6 +715,117 @@ def test_remove_assets_mutation_returns_false(mock_datahub_client):
         return_value=mock_datahub_client,
     ):
         with pytest.raises(RuntimeError, match="Failed to remove assets"):
+            remove_assets_from_data_product(
+                data_product_urn=dp_urn, entity_urns=[dataset_urn]
+            )
+
+
+def test_remove_assets_empty_data_product_urn(mock_datahub_client):
+    """Test that empty data_product_urn raises ValueError."""
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="data_product_urn cannot be empty"):
+            remove_assets_from_data_product(
+                data_product_urn="", entity_urns=[dataset_urn]
+            )
+
+
+def test_remove_assets_empty_entity_urns(mock_datahub_client):
+    """Test that empty entity_urns raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="entity_urns cannot be empty"):
+            remove_assets_from_data_product(
+                data_product_urn="urn:li:dataProduct:customer-360", entity_urns=[]
+            )
+
+
+def test_remove_assets_nonexistent_data_product(mock_datahub_client):
+    """Test that a nonexistent Data Product URN returns an error."""
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    mock_datahub_client._graph.execute_graphql.return_value = {"entity": None}
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Data Product URN does not exist"):
+            remove_assets_from_data_product(
+                data_product_urn="urn:li:dataProduct:nonexistent",
+                entity_urns=[dataset_urn],
+            )
+
+
+def test_remove_assets_invalid_data_product_type(mock_datahub_client):
+    """Test that a URN with the wrong entity type returns an error."""
+    dp_urn = "urn:li:tag:not-a-data-product"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {"urn": dp_urn, "type": "TAG"}
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="not a Data Product entity"):
+            remove_assets_from_data_product(
+                data_product_urn=dp_urn, entity_urns=[dataset_urn]
+            )
+
+
+def test_remove_assets_validation_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during Data Product validation."""
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "Connection timeout"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Failed to validate Data Product URN"):
+            remove_assets_from_data_product(
+                data_product_urn="urn:li:dataProduct:customer-360",
+                entity_urns=[dataset_urn],
+            )
+
+
+def test_remove_assets_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL errors during the remove-assets mutation itself."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        Exception("Network error"),
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(
+            RuntimeError, match="Error removing assets from Data Product"
+        ):
             remove_assets_from_data_product(
                 data_product_urn=dp_urn, entity_urns=[dataset_urn]
             )

--- a/tests/test_mcp/tools/test_data_products.py
+++ b/tests/test_mcp/tools/test_data_products.py
@@ -1,0 +1,411 @@
+"""Tests for Data Product management tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub_integrations.mcp.tools.data_products import (
+    add_assets_to_data_product,
+    create_data_product,
+    delete_data_product,
+    remove_assets_from_data_product,
+    update_data_product,
+)
+
+
+@pytest.fixture
+def mock_datahub_client():
+    """Create a mock DataHub client."""
+    mock_client = MagicMock()
+    mock_client._graph = MagicMock()
+    mock_client._graph.execute_graphql = MagicMock()
+    return mock_client
+
+
+# create_data_product tests
+
+
+def test_create_data_product_success(mock_datahub_client):
+    """Test creating a Data Product under an existing domain."""
+    domain_urn = "urn:li:domain:marketing"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        # First call: domain validation
+        {
+            "entity": {
+                "urn": domain_urn,
+                "type": "DOMAIN",
+                "properties": {"name": "Marketing"},
+            }
+        },
+        # Second call: createDataProduct mutation
+        {"createDataProduct": {"urn": "urn:li:dataProduct:customer-360"}},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = create_data_product(
+            name="Customer 360", domain_urn=domain_urn, description="Unified view"
+        )
+
+    assert result["success"] is True
+    assert result["urn"] == "urn:li:dataProduct:customer-360"
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert mutation_call.kwargs["operation_name"] == "createDataProduct"
+    assert mutation_call.kwargs["variables"]["input"]["domainUrn"] == domain_urn
+    assert mutation_call.kwargs["variables"]["input"]["properties"]["name"] == (
+        "Customer 360"
+    )
+    assert mutation_call.kwargs["variables"]["input"]["properties"]["description"] == (
+        "Unified view"
+    )
+
+
+def test_create_data_product_with_custom_id(mock_datahub_client):
+    """Test creating a Data Product with a custom id."""
+    domain_urn = "urn:li:domain:sales"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": domain_urn, "type": "DOMAIN"}},
+        {"createDataProduct": {"urn": "urn:li:dataProduct:order-analytics"}},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = create_data_product(
+            name="Order Analytics", domain_urn=domain_urn, id="order-analytics"
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert mutation_call.kwargs["variables"]["input"]["id"] == "order-analytics"
+
+
+def test_create_data_product_empty_name(mock_datahub_client):
+    """Test that empty name raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            create_data_product(name="", domain_urn="urn:li:domain:marketing")
+
+
+def test_create_data_product_empty_domain_urn(mock_datahub_client):
+    """Test that empty domain_urn raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="domain_urn cannot be empty"):
+            create_data_product(name="Customer 360", domain_urn="")
+
+
+def test_create_data_product_nonexistent_domain(mock_datahub_client):
+    """Test that a nonexistent domain URN returns an error."""
+    mock_datahub_client._graph.execute_graphql.return_value = {"entity": None}
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Domain URN does not exist"):
+            create_data_product(
+                name="Customer 360", domain_urn="urn:li:domain:nonexistent"
+            )
+
+
+def test_create_data_product_mutation_returns_no_urn(mock_datahub_client):
+    """Test handling when the create mutation returns no urn."""
+    domain_urn = "urn:li:domain:marketing"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": domain_urn, "type": "DOMAIN"}},
+        {"createDataProduct": None},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to create Data Product"):
+            create_data_product(name="Customer 360", domain_urn=domain_urn)
+
+
+# update_data_product tests
+
+
+def test_update_data_product_success(mock_datahub_client):
+    """Test updating a Data Product's description."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"updateDataProduct": {"urn": dp_urn}},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_data_product(
+            data_product_urn=dp_urn, description="Updated description"
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert mutation_call.kwargs["variables"]["input"]["description"] == (
+        "Updated description"
+    )
+    assert "name" not in mutation_call.kwargs["variables"]["input"]
+
+
+def test_update_data_product_no_fields_provided(mock_datahub_client):
+    """Test that omitting both name and description raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="At least one of name or description"):
+            update_data_product(data_product_urn="urn:li:dataProduct:customer-360")
+
+
+def test_update_data_product_nonexistent(mock_datahub_client):
+    """Test that a nonexistent Data Product URN returns an error."""
+    mock_datahub_client._graph.execute_graphql.return_value = {"entity": None}
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="Data Product URN does not exist"):
+            update_data_product(
+                data_product_urn="urn:li:dataProduct:nonexistent", name="New Name"
+            )
+
+
+# delete_data_product tests
+
+
+def test_delete_data_product_success(mock_datahub_client):
+    """Test deleting a Data Product."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"deleteDataProduct": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = delete_data_product(data_product_urn=dp_urn)
+
+    assert result["success"] is True
+
+
+def test_delete_data_product_empty_urn(mock_datahub_client):
+    """Test that empty data_product_urn raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="data_product_urn cannot be empty"):
+            delete_data_product(data_product_urn="")
+
+
+def test_delete_data_product_mutation_returns_false(mock_datahub_client):
+    """Test handling when the delete mutation returns false."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"deleteDataProduct": False},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to delete Data Product"):
+            delete_data_product(data_product_urn=dp_urn)
+
+
+# add_assets_to_data_product / remove_assets_from_data_product tests
+
+
+def test_add_assets_multiple_dp_per_asset_enabled(mock_datahub_client):
+    """When the feature flag is on, assets are added via batchAddToDataProducts."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},  # validate DP
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": True}}},
+        {"batchAddToDataProducts": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_assets_to_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert mutation_call.kwargs["operation_name"] == "batchAddToDataProducts"
+    assert mutation_call.kwargs["variables"]["input"]["dataProductUrns"] == [dp_urn]
+    assert mutation_call.kwargs["variables"]["input"]["resourceUrns"] == [dataset_urn]
+
+
+def test_add_assets_multiple_dp_per_asset_disabled(mock_datahub_client):
+    """When the feature flag is off, assets are added via batchSetDataProduct."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        {"batchSetDataProduct": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_assets_to_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert result["success"] is True
+    assert "replacing any prior Data Product assignment" in result["message"]
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert mutation_call.kwargs["operation_name"] == "batchSetDataProduct"
+    assert mutation_call.kwargs["variables"]["input"]["dataProductUrn"] == dp_urn
+    assert mutation_call.kwargs["variables"]["input"]["resourceUrns"] == [dataset_urn]
+
+
+def test_add_assets_feature_flag_check_fails_closed(mock_datahub_client):
+    """When the feature-flag query itself errors, fall back to batchSetDataProduct."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    # Use a generic error (not a field-validation-style message) so the real
+    # graphql_helpers.execute_graphql wrapper doesn't itself retry the query --
+    # this test is about our own fail-closed handling, not that retry path.
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        Exception("Network timeout contacting GMS"),
+        {"batchSetDataProduct": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = add_assets_to_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert mutation_call.kwargs["operation_name"] == "batchSetDataProduct"
+
+
+def test_add_assets_empty_entity_urns(mock_datahub_client):
+    """Test that empty entity_urns raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="entity_urns cannot be empty"):
+            add_assets_to_data_product(
+                data_product_urn="urn:li:dataProduct:customer-360", entity_urns=[]
+            )
+
+
+def test_remove_assets_multiple_dp_per_asset_enabled(mock_datahub_client):
+    """When the feature flag is on, assets are removed via batchRemoveFromDataProducts."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": True}}},
+        {"batchRemoveFromDataProducts": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = remove_assets_from_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert mutation_call.kwargs["operation_name"] == "batchRemoveFromDataProducts"
+    assert mutation_call.kwargs["variables"]["input"]["dataProductUrns"] == [dp_urn]
+
+
+def test_remove_assets_multiple_dp_per_asset_disabled(mock_datahub_client):
+    """When the feature flag is off, assets are unset via batchSetDataProduct(null)."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        {"batchSetDataProduct": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = remove_assets_from_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert result["success"] is True
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert mutation_call.kwargs["operation_name"] == "batchSetDataProduct"
+    assert mutation_call.kwargs["variables"]["input"]["dataProductUrn"] is None
+
+
+def test_remove_assets_mutation_returns_false(mock_datahub_client):
+    """Test handling when the remove mutation returns false."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        {"batchSetDataProduct": False},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to remove assets"):
+            remove_assets_from_data_product(
+                data_product_urn=dp_urn, entity_urns=[dataset_urn]
+            )

--- a/tests/test_mcp/tools/test_data_products.py
+++ b/tests/test_mcp/tools/test_data_products.py
@@ -110,6 +110,16 @@ def test_create_data_product_empty_name(mock_datahub_client):
             create_data_product(name="", domain_urn="urn:li:domain:marketing")
 
 
+def test_create_data_product_whitespace_only_name(mock_datahub_client):
+    """Test that a whitespace-only name raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            create_data_product(name="   ", domain_urn="urn:li:domain:marketing")
+
+
 def test_create_data_product_empty_domain_urn(mock_datahub_client):
     """Test that empty domain_urn raises ValueError."""
     with patch(
@@ -242,6 +252,18 @@ def test_update_data_product_empty_urn(mock_datahub_client):
     ):
         with pytest.raises(ValueError, match="data_product_urn cannot be empty"):
             update_data_product(data_product_urn="", name="New Name")
+
+
+def test_update_data_product_whitespace_only_name(mock_datahub_client):
+    """Test that a whitespace-only name raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            update_data_product(
+                data_product_urn="urn:li:dataProduct:customer-360", name="   "
+            )
 
 
 def test_update_data_product_nonexistent(mock_datahub_client):
@@ -513,6 +535,41 @@ def test_add_assets_feature_flag_check_fails_closed(mock_datahub_client):
     assert mutation_call.kwargs["operation_name"] == "batchSetDataProduct"
 
 
+def test_add_assets_feature_flag_cache_hit_skips_flag_query(mock_datahub_client):
+    """Once the multipleDataProductsPerAsset flag is cached for a graph, a
+    second call against the same client skips the flag GraphQL query entirely."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": True}}},
+        {"batchAddToDataProducts": True},
+        # Second call: only validate + mutation, no flag query.
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"batchAddToDataProducts": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        first = add_assets_to_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+        second = add_assets_to_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert mock_datahub_client._graph.execute_graphql.call_count == 5
+    second_mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[4]
+    assert second_mutation_call.kwargs["operation_name"] == "batchAddToDataProducts"
+
+
 def test_add_assets_empty_entity_urns(mock_datahub_client):
     """Test that empty entity_urns raises ValueError."""
     with patch(
@@ -670,8 +727,22 @@ def test_remove_assets_multiple_dp_per_asset_enabled(mock_datahub_client):
     assert mutation_call.kwargs["variables"]["input"]["dataProductUrns"] == [dp_urn]
 
 
+def _membership_response(*data_product_urns_by_entity):
+    """Build a getCurrentDataProducts-shaped GraphQL response.
+
+    Each positional arg is the current Data Product urn (or None) for the
+    entity at that index, matching entity_urns order.
+    """
+    response = {}
+    for i, current_dp_urn in enumerate(data_product_urns_by_entity):
+        relationships = [{"entity": {"urn": current_dp_urn}}] if current_dp_urn else []
+        response[f"e{i}"] = {"relationships": {"relationships": relationships}}
+    return response
+
+
 def test_remove_assets_multiple_dp_per_asset_disabled(mock_datahub_client):
-    """When the feature flag is off, assets are unset via batchSetDataProduct(null)."""
+    """When the feature flag is off, assets currently assigned to this Data
+    Product are unset via batchSetDataProduct(null)."""
     dp_urn = "urn:li:dataProduct:customer-360"
     dataset_urn = (
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
@@ -680,6 +751,7 @@ def test_remove_assets_multiple_dp_per_asset_disabled(mock_datahub_client):
     mock_datahub_client._graph.execute_graphql.side_effect = [
         {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
         {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        _membership_response(dp_urn),  # dataset_urn is currently in this DP
         {"batchSetDataProduct": True},
     ]
 
@@ -692,9 +764,79 @@ def test_remove_assets_multiple_dp_per_asset_disabled(mock_datahub_client):
         )
 
     assert result["success"] is True
-    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    membership_call = mock_datahub_client._graph.execute_graphql.call_args_list[2]
+    assert membership_call.kwargs["operation_name"] == "getCurrentDataProducts"
+    assert "DataProductContains" in membership_call.kwargs["query"]
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[3]
     assert mutation_call.kwargs["operation_name"] == "batchSetDataProduct"
     assert mutation_call.kwargs["variables"]["input"]["dataProductUrn"] is None
+    assert mutation_call.kwargs["variables"]["input"]["resourceUrns"] == [dataset_urn]
+
+
+def test_remove_assets_skips_assets_not_in_this_data_product(mock_datahub_client):
+    """When the feature flag is off, only assets currently assigned to THIS
+    Data Product are unset; assets belonging to a different Data Product are
+    left untouched and reported as skipped."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    other_dp_urn = "urn:li:dataProduct:other-product"
+    in_this_dp = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+    in_other_dp = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        _membership_response(dp_urn, other_dp_urn),
+        {"batchSetDataProduct": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = remove_assets_from_data_product(
+            data_product_urn=dp_urn, entity_urns=[in_this_dp, in_other_dp]
+        )
+
+    assert result["success"] is True
+    assert in_other_dp in result["message"]
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[3]
+    # Only the asset actually in this Data Product is sent to the mutation --
+    # the one in a different Data Product must never be touched.
+    assert mutation_call.kwargs["variables"]["input"]["resourceUrns"] == [in_this_dp]
+
+
+def test_remove_assets_no_matching_assets(mock_datahub_client):
+    """When none of the given assets are currently in this Data Product, the
+    tool no-ops without calling the unset mutation at all."""
+    dp_urn = "urn:li:dataProduct:customer-360"
+    other_dp_urn = "urn:li:dataProduct:other-product"
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.customers,PROD)"
+    )
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
+        {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        _membership_response(other_dp_urn),
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = remove_assets_from_data_product(
+            data_product_urn=dp_urn, entity_urns=[dataset_urn]
+        )
+
+    assert result["success"] is True
+    assert "No assets were removed" in result["message"]
+    # No mutation call should have been made -- only validate, flag-check, and
+    # the membership lookup.
+    assert mock_datahub_client._graph.execute_graphql.call_count == 3
 
 
 def test_remove_assets_mutation_returns_false(mock_datahub_client):
@@ -707,6 +849,7 @@ def test_remove_assets_mutation_returns_false(mock_datahub_client):
     mock_datahub_client._graph.execute_graphql.side_effect = [
         {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
         {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        _membership_response(dp_urn),
         {"batchSetDataProduct": False},
     ]
 
@@ -816,6 +959,7 @@ def test_remove_assets_graphql_exception(mock_datahub_client):
     mock_datahub_client._graph.execute_graphql.side_effect = [
         {"entity": {"urn": dp_urn, "type": "DATA_PRODUCT"}},
         {"appConfig": {"featureFlags": {"multipleDataProductsPerAsset": False}}},
+        _membership_response(dp_urn),
         Exception("Network error"),
     ]
 


### PR DESCRIPTION
## Summary
- Adds five new MCP mutation tools for Data Product lifecycle management: `create_data_product`, `update_data_product`, `delete_data_product`, `add_assets_to_data_product`, `remove_assets_from_data_product`.
- `add_assets_to_data_product`/`remove_assets_from_data_product` detect whether the connected instance has the `multipleDataProductsPerAsset` feature flag enabled and use the appropriate mutation (`batchAddToDataProducts`/`batchRemoveFromDataProducts` vs. the older single-Data-Product `batchSetDataProduct`).
- On instances without `multipleDataProductsPerAsset`, `batchSetDataProduct(null)` clears whatever Data Product is currently set on a resource regardless of which urn was requested, so `remove_assets_from_data_product` first looks up each asset's current Data Product via the `DataProductContains` relationship and only unsets assets that actually belong to the requested Data Product, skipping (and reporting) the rest.
- Adds a smoke check covering the create -> add -> remove -> delete lifecycle.

## Test plan
- [x] `uv run pytest tests/test_mcp/tools/test_data_products.py -q` — 48 passed
- [x] `uv run pytest -q` (full suite) — 579 passed, 9 skipped
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run mypy src/mcp_server_datahub/tools/data_products.py` — clean
- [x] Verified all GraphQL mutation/query shapes (`createDataProduct`, `updateDataProduct`, `deleteDataProduct`, `batchSetDataProduct`, `batchAddToDataProducts`, `batchRemoveFromDataProducts`, `DataProductContains` relationship) against the DataHub GraphQL schema