### PR TITLE
feat(tools): add incident management tools (get_incidents, raise_incident, update_incident_status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ List schema fields for a dataset with keyword filtering and pagination, useful w
 
 Retrieve the exact lineage paths between two assets or columns, including intermediate transformations and SQL query information.
 
+### Data Quality Tools
+
+These tools surface data reliability signals. They are enabled via the `DATA_QUALITY_TOOLS_ENABLED=true` environment variable.
+
+`get_dataset_assertions`
+
+Fetch data quality assertions and their recent run results for a dataset, with filtering by column, assertion type, and status. (DataHub Cloud only.)
+
+`get_incidents`
+
+Get incidents raised on an entity (dataset, dashboard, chart, dataFlow, dataJob), with filtering by state (ACTIVE/RESOLVED) and pagination.
+
 ### Mutation Tools
 
 These tools allow modifying metadata in DataHub. They are enabled via the `TOOLS_IS_MUTATION_ENABLED=true` environment variable.
@@ -121,6 +133,10 @@ Update, append to, or remove descriptions for entities or schema fields. Support
 `add_structured_properties` / `remove_structured_properties`
 
 Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types.
+
+`raise_incident` / `update_incident_status`
+
+Raise incidents (freshness, volume, field-level quality, schema, operational, or custom) on affected entities, and update or resolve them — so agents that detect data problems can record them where owners and consumers will see them.
 
 ### User Tools
 
@@ -152,8 +168,9 @@ Save standalone documents (insights, decisions, FAQs, notes) to DataHub's knowle
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TOOLS_IS_MUTATION_ENABLED` | `false` | Enable mutation tools (add/remove tags, owners, etc.) |
+| `TOOLS_IS_MUTATION_ENABLED` | `false` | Enable mutation tools (add/remove tags, owners, incidents, etc.) |
 | `TOOLS_IS_USER_ENABLED` | `false` | Enable user tools (get_me) |
+| `DATA_QUALITY_TOOLS_ENABLED` | `false` | Enable data quality tools (get_dataset_assertions, get_incidents) |
 | `DATAHUB_MCP_DOCUMENT_TOOLS_DISABLED` | `false` | Completely disable document tools |
 | `SAVE_DOCUMENT_TOOL_ENABLED` | `true` | Enable/disable the save_document tool |
 | `SAVE_DOCUMENT_PARENT_TITLE` | `Shared` | Title for the parent folder of saved documents |

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -71,6 +71,7 @@ from .tools.documents import grep_documents, search_documents
 from .tools.domains import remove_domains, set_domains
 from .tools.entities import get_entities, list_schema_fields
 from .tools.get_me import get_me
+from .tools.incidents import get_incidents, raise_incident, update_incident_status
 from .tools.lineage import (  # noqa: F401 (re-exported for backward compat)
     AssetLineageAPI,
     AssetLineageDirective,
@@ -123,6 +124,11 @@ DATA_QUALITY_TOOLS = [
     (
         "get_dataset_assertions",
         get_dataset_assertions,
+        {ToolType.SEARCH.value},
+    ),
+    (
+        "get_incidents",
+        get_incidents,
         {ToolType.SEARCH.value},
     ),
 ]
@@ -261,6 +267,15 @@ def register_mutation_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None
     _register_tool(mcp_instance, "add_structured_properties", add_structured_properties)
     _register_tool(
         mcp_instance, "remove_structured_properties", remove_structured_properties
+    )
+    _register_tool(
+        mcp_instance, "raise_incident", raise_incident, tags={ToolType.MUTATION.value}
+    )
+    _register_tool(
+        mcp_instance,
+        "update_incident_status",
+        update_incident_status,
+        tags={ToolType.MUTATION.value},
     )
 
     # Register save_document tool (only if enabled via environment variable)

--- a/src/mcp_server_datahub/tools/__init__.py
+++ b/src/mcp_server_datahub/tools/__init__.py
@@ -6,6 +6,7 @@ from .documents import grep_documents, search_documents
 from .domains import remove_domains, set_domains
 from .entities import get_entities, list_schema_fields
 from .get_me import get_me
+from .incidents import get_incidents, raise_incident, update_incident_status
 from .lineage import get_lineage, get_lineage_paths_between
 from .owners import add_owners, remove_owners
 from .search import enhanced_search, search
@@ -27,11 +28,13 @@ __all__ = [
     "enhanced_search",
     "get_dataset_queries",
     "get_entities",
+    "get_incidents",
     "get_lineage",
     "get_lineage_paths_between",
     "get_me",
     "grep_documents",
     "list_schema_fields",
+    "raise_incident",
     "remove_domains",
     "remove_glossary_terms",
     "remove_owners",
@@ -41,4 +44,5 @@ __all__ = [
     "search_documents",
     "set_domains",
     "update_description",
+    "update_incident_status",
 ]

--- a/src/mcp_server_datahub/tools/incidents.py
+++ b/src/mcp_server_datahub/tools/incidents.py
@@ -1,0 +1,337 @@
+"""Incident management tools for the DataHub MCP server.
+
+Destination: src/mcp_server_datahub/tools/incidents.py in acryldata/mcp-server-datahub.
+House style per docs/research/mcp-server-pr-brief.md; GraphQL shapes verified by live
+introspection + execution against DataHub OSS v1.5.0.6 (docs/research/gate-a-results.md):
+- IncidentType enum includes FIELD (docs' COLUMN is wrong)
+- priority is an IncidentPriority enum, not an int
+- updateIncidentStatus takes IncidentStatusInput (NOT UpdateIncidentStatusInput,
+  which also exists in the schema and causes a VariableTypeMismatch)
+- raiseIncident rejects mlModel resource urns on OSS v1.5 (documented in docstring)
+"""
+
+import logging
+from typing import Any, List, Literal, Optional
+
+from .. import graphql_helpers
+from ..sub_entity_urls import SUB_ENTITY_CONFIGS, make_sub_entity_url
+from ..version_requirements import min_version, read_only
+
+logger = logging.getLogger(__name__)
+
+# Literal (not Enum) for FastMCP/pydantic JSON Schema generation, matching the
+# precedent in tools/assertions.py.
+IncidentType = Literal[
+    "FRESHNESS", "VOLUME", "FIELD", "SQL", "DATA_SCHEMA", "OPERATIONAL", "CUSTOM"
+]
+IncidentState = Literal["ACTIVE", "RESOLVED"]
+IncidentStage = Literal[
+    "TRIAGE", "INVESTIGATION", "WORK_IN_PROGRESS", "FIXED", "NO_ACTION_REQUIRED"
+]
+IncidentPriority = Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+DEFAULT_PAGE_SIZE = 10
+MAX_PAGE_SIZE = 50
+
+GET_INCIDENTS_QUERY = """
+query getEntityIncidents($urn: String!, $state: IncidentState, $start: Int!, $count: Int!) {
+    entity(urn: $urn) {
+        urn
+        type
+        ... on Dataset {
+            incidents(state: $state, start: $start, count: $count) {
+                ...incidentsFields
+            }
+        }
+        ... on Dashboard {
+            incidents(state: $state, start: $start, count: $count) {
+                ...incidentsFields
+            }
+        }
+        ... on Chart {
+            incidents(state: $state, start: $start, count: $count) {
+                ...incidentsFields
+            }
+        }
+        ... on DataFlow {
+            incidents(state: $state, start: $start, count: $count) {
+                ...incidentsFields
+            }
+        }
+        ... on DataJob {
+            incidents(state: $state, start: $start, count: $count) {
+                ...incidentsFields
+            }
+        }
+    }
+}
+
+fragment incidentsFields on EntityIncidentsResult {
+    start
+    count
+    total
+    incidents {
+        urn
+        incidentType
+        customType
+        title
+        description
+        priority
+        startedAt
+        created { time actor }
+        incidentStatus { state stage message lastUpdated { time actor } }
+        assignees {
+            ... on CorpUser { urn username }
+            ... on CorpGroup { urn name }
+        }
+    }
+}
+"""
+
+RAISE_INCIDENT_MUTATION = """
+mutation raiseIncident($input: RaiseIncidentInput!) {
+    raiseIncident(input: $input)
+}
+"""
+
+# NB: the mutation's input type is IncidentStatusInput. An UpdateIncidentStatusInput
+# type also exists in the GraphQL schema but is not what this mutation accepts.
+UPDATE_INCIDENT_STATUS_MUTATION = """
+mutation updateIncidentStatus($urn: String!, $input: IncidentStatusInput!) {
+    updateIncidentStatus(urn: $urn, input: $input)
+}
+"""
+
+
+@read_only
+@min_version(cloud="0.3.16", oss="1.4.0")
+def get_incidents(
+    entity_urn: str,
+    state: Optional[IncidentState] = "ACTIVE",
+    start: int = 0,
+    count: int = DEFAULT_PAGE_SIZE,
+) -> dict[str, Any]:
+    """Get incidents raised on a DataHub entity (dataset, dashboard, chart, dataFlow, dataJob).
+
+    Incidents track data reliability problems (freshness, volume, field-level quality,
+    schema changes, operational issues) directly on the affected asset, so both humans
+    and agents see them where they look for the data.
+
+    Args:
+        entity_urn: URN of the entity whose incidents to fetch.
+        state: Filter by incident state ("ACTIVE" or "RESOLVED"). Pass null for all.
+        start: Pagination offset.
+        count: Page size (max 50).
+
+    Returns:
+        Dictionary with:
+        - success: True
+        - data: {start, count, total, incidents: [...]} where each incident has
+          urn, incidentType, customType, title, description, priority, status, assignees
+        - message: Summary string
+
+    Examples:
+        # Active incidents on a dataset
+        get_incidents(entity_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)")
+
+        # Full incident history
+        get_incidents(entity_urn="urn:li:dataset:(...)", state=None, count=50)
+    """
+    if not entity_urn:
+        raise ValueError("entity_urn cannot be empty")
+    start = max(0, start)
+    count = max(1, min(count, MAX_PAGE_SIZE))
+    client = graphql_helpers.get_datahub_client()
+
+    result = graphql_helpers.execute_graphql(
+        client._graph,
+        query=GET_INCIDENTS_QUERY,
+        variables={"urn": entity_urn, "state": state, "start": start, "count": count},
+        operation_name="getEntityIncidents",
+    )
+    entity = result.get("entity") or {}
+    incidents_result = entity.get("incidents")
+    if incidents_result is None:
+        raise ValueError(
+            f"Entity {entity_urn} does not support incidents "
+            f"(type: {entity.get('type', 'unknown')})"
+        )
+
+    incidents = incidents_result.get("incidents") or []
+    try:
+        incident_config = SUB_ENTITY_CONFIGS["incident"]
+        frontend_base_url: str = client._graph.frontend_base_url
+        for incident in incidents:
+            if incident.get("urn"):
+                incident["url"] = make_sub_entity_url(
+                    frontend_base_url, incident["urn"], entity_urn, incident_config
+                )
+    except Exception:
+        logger.warning("Could not inject incident URLs", exc_info=True)
+
+    data = {
+        "start": incidents_result.get("start", start),
+        "count": incidents_result.get("count", len(incidents)),
+        "total": incidents_result.get("total", len(incidents)),
+        "incidents": graphql_helpers.clean_gql_response(incidents),
+    }
+    return {
+        "success": True,
+        "data": data,
+        "message": f"Found {data['total']} incident(s) on {entity_urn}",
+    }
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def raise_incident(
+    entity_urn: str,
+    incident_type: IncidentType,
+    title: str,
+    description: Optional[str] = None,
+    priority: Optional[IncidentPriority] = None,
+    custom_type: Optional[str] = None,
+    started_at_millis: Optional[int] = None,
+    assignee_urns: Optional[List[str]] = None,
+) -> dict[str, Any]:
+    """Raise (create) a new incident on a DataHub entity.
+
+    This is the write-back half of data reliability workflows: after an agent or
+    check detects a problem, raising an incident records it on the asset itself so
+    downstream consumers and owners see it in DataHub.
+
+    Note: supported resource entity types depend on the server (datasets, dashboards,
+    charts, dataFlows, dataJobs are broadly supported; some versions reject e.g.
+    mlModel urns — the mutation fails loudly with a GraphQL error in that case).
+
+    Args:
+        entity_urn: URN of the affected entity.
+        incident_type: One of FRESHNESS, VOLUME, FIELD, SQL, DATA_SCHEMA,
+            OPERATIONAL, CUSTOM.
+        title: Short human-readable summary.
+        description: Longer context — markdown supported in the UI.
+        priority: LOW, MEDIUM, HIGH, or CRITICAL.
+        custom_type: Required when incident_type is CUSTOM; a free-form label.
+        started_at_millis: Epoch millis when the problem began (defaults to now
+            server-side).
+        assignee_urns: corpuser/corpGroup urns to assign.
+
+    Returns:
+        Dictionary with:
+        - success: True
+        - urn: The new incident's urn
+        - message: Confirmation string
+
+    Examples:
+        raise_incident(
+            entity_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)",
+            incident_type="FRESHNESS",
+            title="orders table is 3 days stale",
+            description="Upstream load job has not written rows since 2026-03-01.",
+            priority="CRITICAL",
+        )
+    """
+    if not entity_urn:
+        raise ValueError("entity_urn cannot be empty")
+    if not title:
+        raise ValueError("title cannot be empty")
+    if incident_type == "CUSTOM" and not custom_type:
+        raise ValueError("custom_type is required when incident_type='CUSTOM'")
+
+    client = graphql_helpers.get_datahub_client()
+    incident_input: dict[str, Any] = {
+        "resourceUrn": entity_urn,
+        "type": incident_type,
+        "title": title,
+    }
+    if description:
+        incident_input["description"] = description
+    if priority:
+        incident_input["priority"] = priority
+    if custom_type:
+        incident_input["customType"] = custom_type
+    if started_at_millis is not None:
+        incident_input["startedAt"] = started_at_millis
+    if assignee_urns:
+        incident_input["assigneeUrns"] = assignee_urns
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=RAISE_INCIDENT_MUTATION,
+            variables={"input": incident_input},
+            operation_name="raiseIncident",
+        )
+        incident_urn = result.get("raiseIncident")
+        if not incident_urn:
+            raise RuntimeError("Failed to raise incident - operation returned no urn")
+        return {
+            "success": True,
+            "urn": incident_urn,
+            "message": f"Raised {incident_type} incident on {entity_urn}: {title}",
+        }
+    except Exception as e:
+        if isinstance(e, (RuntimeError, ValueError)):
+            raise
+        raise RuntimeError(f"Error raising incident: {str(e)}") from e
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def update_incident_status(
+    incident_urn: str,
+    state: IncidentState,
+    stage: Optional[IncidentStage] = None,
+    message: Optional[str] = None,
+) -> dict[str, Any]:
+    """Update the status of an existing DataHub incident (e.g., resolve it).
+
+    Args:
+        incident_urn: URN of the incident (from get_incidents or raise_incident).
+        state: "ACTIVE" or "RESOLVED".
+        stage: Optional workflow stage: TRIAGE, INVESTIGATION, WORK_IN_PROGRESS,
+            FIXED, NO_ACTION_REQUIRED.
+        message: Optional note recorded with the status change.
+
+    Returns:
+        Dictionary with:
+        - success: True
+        - urn: The incident urn
+        - message: Confirmation string
+
+    Examples:
+        update_incident_status(
+            incident_urn="urn:li:incident:bf7a5117-...",
+            state="RESOLVED",
+            stage="FIXED",
+            message="Backfill completed; freshness assertion green again.",
+        )
+    """
+    if not incident_urn:
+        raise ValueError("incident_urn cannot be empty")
+
+    client = graphql_helpers.get_datahub_client()
+    status_input: dict[str, Any] = {"state": state}
+    if stage:
+        status_input["stage"] = stage
+    if message:
+        status_input["message"] = message
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=UPDATE_INCIDENT_STATUS_MUTATION,
+            variables={"urn": incident_urn, "input": status_input},
+            operation_name="updateIncidentStatus",
+        )
+        if not result.get("updateIncidentStatus", False):
+            raise RuntimeError(
+                "Failed to update incident status - operation returned false"
+            )
+        return {
+            "success": True,
+            "urn": incident_urn,
+            "message": f"Incident status updated to {state}",
+        }
+    except Exception as e:
+        if isinstance(e, (RuntimeError, ValueError)):
+            raise
+        raise RuntimeError(f"Error updating incident status: {str(e)}") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,7 @@ if using_oss:
     assertions_module = sys.modules["mcp_server_datahub.tools.assertions"]
     dataset_queries_module = sys.modules["mcp_server_datahub.tools.dataset_queries"]
     entities_module = sys.modules["mcp_server_datahub.tools.entities"]
+    incidents_module = sys.modules["mcp_server_datahub.tools.incidents"]
     lineage_module = sys.modules["mcp_server_datahub.tools.lineage"]
     search_module = sys.modules["mcp_server_datahub.tools.search"]
 
@@ -139,6 +140,7 @@ if using_oss:
     tools_module.domains = domains_module  # type: ignore[attr-defined]
     tools_module.entities = entities_module  # type: ignore[attr-defined]
     tools_module.get_me = get_me_module  # type: ignore[attr-defined]
+    tools_module.incidents = incidents_module  # type: ignore[attr-defined]
     tools_module.lineage = lineage_module  # type: ignore[attr-defined]
     tools_module.owners = owners_module  # type: ignore[attr-defined]
     tools_module.save_document = save_document_module  # type: ignore[attr-defined]
@@ -156,6 +158,7 @@ if using_oss:
     sys.modules["datahub_integrations.mcp.tools.domains"] = domains_module
     sys.modules["datahub_integrations.mcp.tools.entities"] = entities_module
     sys.modules["datahub_integrations.mcp.tools.get_me"] = get_me_module
+    sys.modules["datahub_integrations.mcp.tools.incidents"] = incidents_module
     sys.modules["datahub_integrations.mcp.tools.lineage"] = lineage_module
     sys.modules["datahub_integrations.mcp.tools.owners"] = owners_module
     sys.modules["datahub_integrations.mcp.tools.save_document"] = save_document_module

--- a/tests/test_mcp/tools/test_incidents.py
+++ b/tests/test_mcp/tools/test_incidents.py
@@ -1,0 +1,278 @@
+"""Tests for incident management tools."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_integrations.mcp.tools.incidents import (
+    get_incidents,
+    raise_incident,
+    update_incident_status,
+)
+
+DATASET_URN = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)"
+INCIDENT_URN = "urn:li:incident:bf7a5117-cbae-4b78-a100-dead1812311a"
+
+
+@pytest.fixture
+def mock_datahub_client():
+    """Fixture for mocking DataHubClient."""
+    mock_client = Mock()
+    mock_graph = Mock()
+    mock_client._graph = mock_graph
+    mock_graph.frontend_base_url = "https://datahub.example.com"
+    return mock_client
+
+
+def _incident_entity(state: str = "ACTIVE") -> dict:
+    return {
+        "urn": INCIDENT_URN,
+        "incidentType": "FRESHNESS",
+        "customType": None,
+        "title": "orders table is stale",
+        "description": "Upstream load stopped.",
+        "priority": "CRITICAL",
+        "startedAt": 1700000000000,
+        "created": {"time": 1700000000000, "actor": "urn:li:corpuser:datahub"},
+        "incidentStatus": {
+            "state": state,
+            "stage": "INVESTIGATION",
+            "message": None,
+            "lastUpdated": {"time": 1700000000000, "actor": "urn:li:corpuser:datahub"},
+        },
+        "assignees": [],
+    }
+
+
+class TestGetIncidents:
+    def test_get_incidents_basic(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "entity": {
+                "urn": DATASET_URN,
+                "type": "DATASET",
+                "incidents": {
+                    "start": 0,
+                    "count": 10,
+                    "total": 1,
+                    "incidents": [_incident_entity()],
+                },
+            }
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            result = get_incidents(entity_urn=DATASET_URN)
+
+        assert result["success"] is True
+        assert result["data"]["total"] == 1
+        assert result["data"]["incidents"][0]["urn"] == INCIDENT_URN
+        assert result["data"]["incidents"][0]["incidentType"] == "FRESHNESS"
+
+        variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs[
+            "variables"
+        ]
+        assert variables["urn"] == DATASET_URN
+        assert variables["state"] == "ACTIVE"
+
+    def test_get_incidents_empty(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "entity": {
+                "urn": DATASET_URN,
+                "type": "DATASET",
+                "incidents": {"start": 0, "count": 10, "total": 0, "incidents": []},
+            }
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            result = get_incidents(entity_urn=DATASET_URN)
+
+        assert result["success"] is True
+        assert result["data"]["total"] == 0
+        assert result["data"]["incidents"] == []
+
+    def test_get_incidents_unsupported_entity(self, mock_datahub_client):
+        """Entities without an incidents field (e.g. a tag) raise a clear error."""
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "entity": {"urn": "urn:li:tag:pii", "type": "TAG"}
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            with pytest.raises(ValueError, match="does not support incidents"):
+                get_incidents(entity_urn="urn:li:tag:pii")
+
+    def test_get_incidents_empty_urn(self, mock_datahub_client):
+        with pytest.raises(ValueError, match="entity_urn cannot be empty"):
+            get_incidents(entity_urn="")
+
+    def test_get_incidents_count_clamped(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "entity": {
+                "urn": DATASET_URN,
+                "type": "DATASET",
+                "incidents": {"start": 0, "count": 50, "total": 0, "incidents": []},
+            }
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            get_incidents(entity_urn=DATASET_URN, count=500)
+
+        variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs[
+            "variables"
+        ]
+        assert variables["count"] == 50
+
+
+class TestRaiseIncident:
+    def test_raise_incident_basic(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "raiseIncident": INCIDENT_URN
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            result = raise_incident(
+                entity_urn=DATASET_URN,
+                incident_type="FRESHNESS",
+                title="orders table is stale",
+                description="Upstream load stopped.",
+                priority="CRITICAL",
+            )
+
+        assert result["success"] is True
+        assert result["urn"] == INCIDENT_URN
+
+        variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs[
+            "variables"
+        ]
+        assert variables["input"] == {
+            "resourceUrn": DATASET_URN,
+            "type": "FRESHNESS",
+            "title": "orders table is stale",
+            "description": "Upstream load stopped.",
+            "priority": "CRITICAL",
+        }
+
+    def test_raise_incident_custom_requires_custom_type(self, mock_datahub_client):
+        with pytest.raises(ValueError, match="custom_type is required"):
+            raise_incident(
+                entity_urn=DATASET_URN, incident_type="CUSTOM", title="something odd"
+            )
+
+    def test_raise_incident_custom_type_included(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "raiseIncident": INCIDENT_URN
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            raise_incident(
+                entity_urn=DATASET_URN,
+                incident_type="CUSTOM",
+                custom_type="MODEL_AT_RISK",
+                title="model consuming stale features",
+            )
+
+        variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs[
+            "variables"
+        ]
+        assert variables["input"]["customType"] == "MODEL_AT_RISK"
+
+    def test_raise_incident_empty_title(self, mock_datahub_client):
+        with pytest.raises(ValueError, match="title cannot be empty"):
+            raise_incident(entity_urn=DATASET_URN, incident_type="FRESHNESS", title="")
+
+    def test_raise_incident_no_urn_returned(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "raiseIncident": None
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            with pytest.raises(RuntimeError, match="returned no urn"):
+                raise_incident(
+                    entity_urn=DATASET_URN, incident_type="FRESHNESS", title="stale"
+                )
+
+    def test_raise_incident_graphql_exception_wrapped(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.side_effect = Exception("boom")
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            with pytest.raises(RuntimeError, match="Error raising incident"):
+                raise_incident(
+                    entity_urn=DATASET_URN, incident_type="FRESHNESS", title="stale"
+                )
+
+
+class TestUpdateIncidentStatus:
+    def test_resolve_with_stage_and_message(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "updateIncidentStatus": True
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            result = update_incident_status(
+                incident_urn=INCIDENT_URN,
+                state="RESOLVED",
+                stage="FIXED",
+                message="Backfill completed.",
+            )
+
+        assert result["success"] is True
+        variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs[
+            "variables"
+        ]
+        assert variables["urn"] == INCIDENT_URN
+        assert variables["input"] == {
+            "state": "RESOLVED",
+            "stage": "FIXED",
+            "message": "Backfill completed.",
+        }
+
+    def test_update_empty_urn(self, mock_datahub_client):
+        with pytest.raises(ValueError, match="incident_urn cannot be empty"):
+            update_incident_status(incident_urn="", state="RESOLVED")
+
+    def test_update_returns_false(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.return_value = {
+            "updateIncidentStatus": False
+        }
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            with pytest.raises(RuntimeError, match="operation returned false"):
+                update_incident_status(incident_urn=INCIDENT_URN, state="RESOLVED")
+
+    def test_update_graphql_exception_wrapped(self, mock_datahub_client):
+        mock_datahub_client._graph.execute_graphql.side_effect = Exception("boom")
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            with pytest.raises(RuntimeError, match="Error updating incident status"):
+                update_incident_status(incident_urn=INCIDENT_URN, state="RESOLVED")


### PR DESCRIPTION
Closes #136

Adds incident management to the MCP server: `get_incidents` (read), `raise_incident` and `update_incident_status` (mutations). This closes the loop for data-reliability agents: they can already *find* problems through this server's read tools. Now they can record and resolve them on the affected assets, where owners and consumers actually look.

## What's included

| Change | File |
|---|---|
| The three tools (full docstrings; `Literal` enums for JSON-schema generation) | `src/mcp_server_datahub/tools/incidents.py` |
| Registration: `get_incidents` appended to `DATA_QUALITY_TOOLS` (per the extensible-list refactor in #123); both mutations in `register_mutation_tools()` | `src/mcp_server_datahub/mcp_server.py` |
| Re-exports | `src/mcp_server_datahub/tools/__init__.py` |
| Cross-repo test shim entries | `tests/conftest.py` |
| 15 unit tests mirroring `test_assertions.py` / `test_tags.py` patterns | `tests/test_mcp/tools/test_incidents.py` |
| Docs for the new tools **+ the previously-undocumented `DATA_QUALITY_TOOLS_ENABLED` flag and `get_dataset_assertions` tool** | `README.md` |

No new env vars: the read tool reuses the `DATA_QUALITY_TOOLS_ENABLED` gate, mutations reuse `TOOLS_IS_MUTATION_ENABLED`.

## Design notes

- **`get_incidents` uses the `entity { ... on Dataset { incidents } }` GraphQL field** (the same path the web UI uses) rather than `searchAcrossEntities(types: [INCIDENT])`: it needs no search-index facet assumptions and returns results consistent with what users see on the entity page. Trade-off: an explicit fragment list (Dataset, Dashboard, Chart, DataFlow, DataJob); unsupported entity types raise a clear `ValueError`.
- Incident URL injection follows the `assertions.py` pattern via the existing `SUB_ENTITY_CONFIGS["incident"]`, and degrades to a warning when the server has no `baseUrl` configured (e.g. quickstart).
- GraphQL shapes were verified by introspection + execution against OSS v1.5.0.6. Two findings baked into the implementation: the `IncidentType` enum value is `FIELD` (the docs' `COLUMN` doesn't exist in the schema), and `updateIncidentStatus` takes `IncidentStatusInput`, not the similarly-named `UpdateIncidentStatusInput`, which triggers a `VariableTypeMismatch`.

## Verification

- `uv run pytest tests/test_mcp`: **529 passed** (514 existing + 15 new; no regressions)
- `make lint`: ruff + mypy clean
- Live smoke through the MCP protocol against an OSS v1.5.0.6 quickstart:

```
incident tools registered: ['get_incidents', 'raise_incident', 'update_incident_status']
raise_incident -> {"success": true, "urn": "urn:li:incident:69f5b9b3-...", "message": "Raised FRESHNESS incident on urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD): [smoke] upstream data is stale"}
get_incidents -> total=2, first='[smoke] upstream data is stale'
update_incident_status -> {"success": true, "urn": "urn:li:incident:69f5b9b3-...", "message": "Incident status updated to RESOLVED"}
SMOKE PASS: raise -> get -> resolve through MCP on OSS quickstart
```

## Notes for reviewers

- `@min_version(cloud="0.3.16", oss="1.4.0")`: the `oss` floor matches the other batch mutation tools; happy to adjust if you'd rather verify against the v1.3.0 CI leg first.
- On OSS v1.5, `raiseIncident` rejects `mlModel` resource urns (fails loudly); the docstring documents that supported resource types are server-dependent.
- I did not add cases to `tests/test_mcp_integration.py` since that suite runs read-only in CI (no mutation env flags); if you'd like, I can add an incident round-trip to `scripts/smoke_check.py --mutations` in a follow-up.

## Context

Built for the DataHub Agent Hackathon: our project (an ML-reliability agent that root-causes silent failures through lineage) uses exactly these GraphQL calls for its write-back today, and we'd love for every MCP-based agent to get them out of the box.
