### PR TITLE
fix: align Loguru verbosity with debug flag

### DIFF
--- a/src/mcp_server_datahub/__main__.py
+++ b/src/mcp_server_datahub/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import Any
 
 import click
@@ -8,6 +9,7 @@ from datahub.telemetry import telemetry
 from fastmcp import FastMCP
 from fastmcp.server.middleware import Middleware
 from fastmcp.server.middleware.logging import LoggingMiddleware
+from loguru import logger
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from typing_extensions import Literal
@@ -18,7 +20,20 @@ from mcp_server_datahub.document_tools_middleware import DocumentToolsMiddleware
 from mcp_server_datahub.mcp_server import mcp, register_all_tools, with_datahub_client
 from mcp_server_datahub.version_requirements import VersionFilterMiddleware
 
-logging.basicConfig(level=logging.INFO)
+
+def _configure_logging(*, debug: bool) -> None:
+    """Keep stdlib and Loguru verbosity aligned with the CLI debug flag."""
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(level=level)
+    logging.getLogger().setLevel(level)
+
+    # Loguru ships with a DEBUG-level stderr handler. Replace it so normal MCP
+    # sessions do not emit full GraphQL queries; --debug restores that detail.
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if debug else "INFO")
+
+
+_configure_logging(debug=False)
 
 # Register tools with OSS-compatible descriptions
 register_all_tools(is_oss=True)
@@ -107,6 +122,7 @@ def create_app() -> FastMCP:
 )
 def main(transport: Literal["stdio", "sse", "http"], debug: bool) -> None:
     if debug:
+        _configure_logging(debug=True)
         # Add LoggingMiddleware before create_app() so it becomes the
         # outermost middleware (FastMCP reverses the list) and logs the
         # full request/response including all other middleware effects.

--- a/tests/test_mcp/test_logging.py
+++ b/tests/test_mcp/test_logging.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+
+
+def _run_logging_probe(*, debug: bool) -> subprocess.CompletedProcess[str]:
+    script = f"""
+from loguru import logger
+from mcp_server_datahub.__main__ import _configure_logging
+
+_configure_logging(debug={debug!r})
+logger.debug("MCP_DEBUG_MARKER")
+logger.info("MCP_INFO_MARKER")
+"""
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_default_logging_hides_debug_messages() -> None:
+    result = _run_logging_probe(debug=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "MCP_INFO_MARKER" in result.stderr
+    assert "MCP_DEBUG_MARKER" not in result.stderr
+
+
+def test_debug_logging_shows_debug_messages() -> None:
+    result = _run_logging_probe(debug=True)
+
+    assert result.returncode == 0, result.stderr
+    assert "MCP_INFO_MARKER" in result.stderr
+    assert "MCP_DEBUG_MARKER" in result.stderr


### PR DESCRIPTION
## Summary

- configure Loguru at INFO for normal server runs
- restore Loguru DEBUG output when `--debug` is enabled
- add isolated regression tests for both verbosity modes

## Problem

`logging.basicConfig(level=logging.INFO)` only configures the standard-library logger. Loguru keeps its preconfigured DEBUG-level stderr handler, so normal MCP sessions emit debug entries including full GraphQL queries and variables even when `--debug` is not supplied.

This replaces the default Loguru handler at the application entry point and keeps its threshold aligned with the existing CLI flag.

## Verification

- `uv run pytest tests/test_mcp -q` — 501 passed
- `make lint-check` — formatting, Ruff, and mypy passed

The tests use isolated subprocesses so changing the global Loguru handler does not leak across the suite.