### PR TITLE
docs: add agent-author gotchas (read-after-write consistency, get_lineage scope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,47 @@ The agent may either:
 | `get_lineage_paths_between` | Understand deeper relationships between datasets. |
 
 
+## Notes & Gotchas for Agent Authors
+
+A few behaviors are easy to trip over when building autonomous agents on top of
+these tools — especially agents that both read *and* write metadata. Documenting
+them here so the next builder doesn't have to rediscover them empirically.
+
+### Reads after writes are eventually consistent
+
+DataHub acknowledges a mutation (or an ingestion run) once it has been committed
+to the metadata store (GMS), but the search index (OpenSearch/Elasticsearch)
+that backs `search` is updated **asynchronously** afterward. An agent that
+writes an entity — or ingests a batch of entities — and then immediately calls
+`search` may not see them yet.
+
+If your flow is *ingest/write → search → act* in a single automated pass (for
+example in CI), don't assume the freshly written assets are searchable the
+instant the write returns. Poll until the expected assets appear before relying
+on `search` results, rather than reading once immediately after the write.
+Point lookups by URN (`get_entities`) reflect writes sooner than `search` does,
+since they don't depend on the search index.
+
+### `get_lineage` only traverses lineage relationships
+
+`get_lineage` walks the lineage graph (dataset → dataset, field → field, and
+similar `DownstreamOf`/`Consumes`/`Produces`-style edges). Some relationships
+that *feel* like lineage are modeled as entity aspects rather than lineage
+edges, and those are **not** returned by `get_lineage`. For ML agents in
+particular:
+
+- An `MLModel`'s deployments (`MLModelProperties.deployments`) are an aspect on
+  the model, not a downstream lineage edge — traversing downstream from a model
+  surfaces its `MLModelGroup`, not its `MLModelDeployment`(s).
+- Likewise, an `MLModel`'s features (`MLModelProperties.mlFeatures`) and an
+  `MLFeature`'s sources (`MLFeatureProperties.sources`) are aspect fields.
+
+To read these, fetch the entity's aspects directly (`get_entities`) rather than
+expecting them in a `get_lineage` traversal. Mentioning it because "which
+datasets feed this model, and where is it deployed?" is a natural first question
+for a production-ML agent, and it isn't answerable from lineage alone.
+
+
 ## Developing
 
 See [DEVELOPING.md](DEVELOPING.md).


### PR DESCRIPTION
## What

Adds a short **Notes & Gotchas for Agent Authors** section to the README, right after the existing agent-focused "Data Discovery & Understanding Flow" section.

## Why

While building an autonomous agent that both reads and writes DataHub metadata via this server, I hit two behaviors that aren't documented and that cost real debugging time. Writing them down so the next builder doesn't have to rediscover them empirically:

1. **Reads after writes are eventually consistent.** `search` is backed by the search index, which updates asynchronously after GMS acknowledges a write/ingest. An ingest → search → act flow in a single automated pass (e.g. in CI) can miss freshly written assets. The section notes that point lookups by URN via `get_entities` reflect writes sooner, and suggests polling until expected assets appear before relying on `search`.

2. **`get_lineage` only traverses lineage edges.** Relationships modeled as entity aspects rather than lineage edges are not returned by a traversal. For ML agents specifically, an `MLModel`'s `deployments` and `mlFeatures`, and an `MLFeature`'s `sources`, are aspect fields — traversing downstream from a model surfaces its `MLModelGroup`, not its `MLModelDeployment`(s). These must be read via `get_entities`. This matters because "what feeds this model and where is it deployed?" is a natural first question for a production-ML agent.

Both verified live against a self-hosted OSS DataHub quickstart (GMS `v1.5.0.6`, `mcp-server-datahub` 0.6.0).

## Scope change

This PR originally carried a third finding, about column-level (fine-grained) lineage not being surfaced by any exposed MCP tool. That one describes tool behavior rather than a documentation gap, so it's been moved out of this PR and into the discussion on #197, where it belongs alongside the related column-lineage work.

What's left here is docs-only: +41 lines, one file, no code touched. Happy to adjust wording, scope, or placement — or move it into a dedicated doc — if the team prefers.
