### PR TITLE
feat: add get_dataset_profile tool

### DIFF
--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -82,6 +82,7 @@ from .tools.lineage import (  # noqa: F401 (re-exported for backward compat)
     get_lineage_paths_between,
 )
 from .tools.owners import add_owners, remove_owners
+from .tools.profiles import get_dataset_profile
 from .tools.save_document import is_save_document_enabled, save_document
 from .tools.search import (  # noqa: F401 (re-exported for backward compat)
     _search_implementation,
@@ -375,6 +376,12 @@ def register_search_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None:
         mcp_instance,
         "get_lineage_paths_between",
         get_lineage_paths_between,
+        tags={ToolType.SEARCH.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "get_dataset_profile",
+        get_dataset_profile,
         tags={ToolType.SEARCH.value},
     )
     _register_tool(mcp_instance, "search_documents", search_documents)

--- a/src/mcp_server_datahub/tools/profiles.py
+++ b/src/mcp_server_datahub/tools/profiles.py
@@ -1,0 +1,170 @@
+"""Dataset profile (column statistics) tool for DataHub MCP server."""
+
+import logging
+from typing import Any, Optional
+
+from .. import graphql_helpers
+from ..version_requirements import min_version, read_only
+
+logger = logging.getLogger(__name__)
+
+DATASET_PROFILE_QUERY = """
+query GetDatasetProfile(
+    $urn: String!,
+    $startTimeMillis: Long,
+    $endTimeMillis: Long,
+    $limit: Int
+) {
+    dataset(urn: $urn) {
+        urn
+        datasetProfiles(
+            startTimeMillis: $startTimeMillis
+            endTimeMillis: $endTimeMillis
+            limit: $limit
+        ) {
+            timestampMillis
+            rowCount
+            columnCount
+            sizeInBytes
+            fieldProfiles {
+                fieldPath
+                uniqueCount
+                uniqueProportion
+                nullCount
+                nullProportion
+                min
+                max
+                mean
+                median
+                stdev
+                sampleValues
+            }
+        }
+    }
+}
+"""
+
+DEFAULT_LIMIT = 1
+MAX_LIMIT = 10
+
+
+def _filter_field_profiles(
+    profile: dict[str, Any], columns: Optional[list[str]]
+) -> dict[str, Any]:
+    """Restrict a profile's fieldProfiles to the requested columns, if any.
+
+    Returns a shallow copy so the caller's response object is left untouched.
+    """
+    if not columns:
+        return profile
+
+    wanted = set(columns)
+    field_profiles = profile.get("fieldProfiles") or []
+    return {
+        **profile,
+        "fieldProfiles": [fp for fp in field_profiles if fp.get("fieldPath") in wanted],
+    }
+
+
+@read_only
+@min_version(cloud="0.3.16", oss="1.4.0")
+def get_dataset_profile(
+    urn: str,
+    columns: Optional[list[str]] = None,
+    limit: int = DEFAULT_LIMIT,
+    start_time_millis: Optional[int] = None,
+    end_time_millis: Optional[int] = None,
+) -> dict[str, Any]:
+    """Get profiling statistics (row counts and per-column stats) for a dataset.
+
+    Returns the dataset's most recent profile snapshots: row count, column count,
+    size, and per-column statistics such as null rate, distinct count, min/max,
+    mean, median and sample values.
+
+    Use this to answer questions the schema alone cannot - whether a column has
+    started going null, whether a distribution shifted, whether row counts dropped -
+    and to compare an upstream table's statistics before and after a suspected
+    change. Request several snapshots with `limit` to see how a statistic moved
+    over time.
+
+    Profiles only exist if profiling is enabled for the source ingestion recipe.
+    A dataset with no profiles returns an empty list rather than an error.
+
+    Args:
+        urn: The URN of the dataset (e.g. urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD))
+        columns: Optional list of column paths to return stats for (e.g. ["user_id", "amount"]).
+            Omit for all columns. Filtering is strongly recommended on wide tables, since
+            a full profile of a several-hundred-column table is a large response.
+        limit: Number of profile snapshots to return, newest first (default 1, max 10).
+            Use more than 1 to compare a statistic across time.
+        start_time_millis: Optional epoch-millisecond lower bound on snapshot time.
+        end_time_millis: Optional epoch-millisecond upper bound on snapshot time.
+
+    RESPONSE FIELDS (per profile snapshot):
+    - timestampMillis: When the profile was captured
+    - rowCount / columnCount / sizeInBytes: Table-level statistics
+    - fieldProfiles: Per-column statistics, each containing:
+      - fieldPath: Column name
+      - nullCount / nullProportion: How much of the column is null
+      - uniqueCount / uniqueProportion: Cardinality
+      - min / max / mean / median / stdev: Distribution statistics (numeric columns)
+      - sampleValues: Example values from the column
+
+    Examples:
+        # Latest profile for a whole table
+        get_dataset_profile(urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)")
+
+        # Track one column's null rate over the last few snapshots
+        get_dataset_profile(
+            urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)",
+            columns=["user_id"],
+            limit=5,
+        )
+    """
+    if not urn:
+        raise ValueError("urn cannot be empty")
+    limit = max(1, min(limit, MAX_LIMIT))
+
+    client = graphql_helpers.get_datahub_client()
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=DATASET_PROFILE_QUERY,
+            variables={
+                "urn": urn,
+                "startTimeMillis": start_time_millis,
+                "endTimeMillis": end_time_millis,
+                "limit": limit,
+            },
+            operation_name="GetDatasetProfile",
+        )
+
+        dataset = result.get("dataset")
+        if not dataset:
+            raise ValueError(f"Dataset not found: {urn}")
+
+        profiles = dataset.get("datasetProfiles") or []
+        profiles = [_filter_field_profiles(p, columns) for p in profiles]
+        profiles = [graphql_helpers.clean_gql_response(p) for p in profiles]
+
+        if not profiles:
+            return {
+                "success": True,
+                "data": {"urn": urn, "count": 0, "profiles": []},
+                "message": (
+                    f"No profiles found for {urn}. Profiling may not be enabled "
+                    "for this dataset's ingestion source."
+                ),
+            }
+
+        return {
+            "success": True,
+            "data": {"urn": urn, "count": len(profiles), "profiles": profiles},
+            "message": f"Found {len(profiles)} profile snapshot(s) for dataset",
+        }
+
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise RuntimeError(f"Error fetching profile for dataset {urn}: {e}") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,7 @@ if using_oss:
     domains_module = sys.modules["mcp_server_datahub.tools.domains"]
     get_me_module = sys.modules["mcp_server_datahub.tools.get_me"]
     owners_module = sys.modules["mcp_server_datahub.tools.owners"]
+    profiles_module = sys.modules["mcp_server_datahub.tools.profiles"]
     save_document_module = sys.modules["mcp_server_datahub.tools.save_document"]
     structured_properties_module = sys.modules[
         "mcp_server_datahub.tools.structured_properties"
@@ -141,6 +142,7 @@ if using_oss:
     tools_module.get_me = get_me_module  # type: ignore[attr-defined]
     tools_module.lineage = lineage_module  # type: ignore[attr-defined]
     tools_module.owners = owners_module  # type: ignore[attr-defined]
+    tools_module.profiles = profiles_module  # type: ignore[attr-defined]
     tools_module.save_document = save_document_module  # type: ignore[attr-defined]
     tools_module.search = search_module  # type: ignore[attr-defined]
     tools_module.structured_properties = structured_properties_module  # type: ignore[attr-defined]
@@ -158,6 +160,7 @@ if using_oss:
     sys.modules["datahub_integrations.mcp.tools.get_me"] = get_me_module
     sys.modules["datahub_integrations.mcp.tools.lineage"] = lineage_module
     sys.modules["datahub_integrations.mcp.tools.owners"] = owners_module
+    sys.modules["datahub_integrations.mcp.tools.profiles"] = profiles_module
     sys.modules["datahub_integrations.mcp.tools.save_document"] = save_document_module
     sys.modules["datahub_integrations.mcp.tools.search"] = search_module
     sys.modules["datahub_integrations.mcp.tools.structured_properties"] = (

--- a/tests/test_mcp/tools/test_profiles.py
+++ b/tests/test_mcp/tools/test_profiles.py
@@ -1,0 +1,160 @@
+import re
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_integrations.mcp.tools.profiles import MAX_LIMIT, get_dataset_profile
+
+DATASET_URN = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)"
+
+PROFILE = {
+    "timestampMillis": 1717200000000,
+    "rowCount": 1000,
+    "columnCount": 2,
+    "sizeInBytes": 4096,
+    "fieldProfiles": [
+        {"fieldPath": "user_id", "nullCount": 0, "uniqueCount": 1000},
+        {"fieldPath": "amount", "nullCount": 12, "uniqueCount": 840},
+    ],
+}
+
+
+@pytest.fixture
+def mock_datahub_client():
+    """Fixture for mocking DataHubClient."""
+    mock_client = Mock()
+    mock_graph = Mock()
+    mock_client._graph = mock_graph
+    return mock_client
+
+
+def _call(mock_client, **kwargs):
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_client,
+    ):
+        return get_dataset_profile(**kwargs)
+
+
+def test_returns_latest_profile(mock_datahub_client):
+    """A basic call returns the dataset's profile snapshots."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": [PROFILE]}
+    }
+
+    result = _call(mock_datahub_client, urn=DATASET_URN)
+
+    assert result["success"] is True
+    assert result["data"]["count"] == 1
+    profile = result["data"]["profiles"][0]
+    assert profile["rowCount"] == 1000
+    assert len(profile["fieldProfiles"]) == 2
+
+
+def test_columns_filter_narrows_field_profiles(mock_datahub_client):
+    """Requesting specific columns drops the rest, keeping responses small."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": [PROFILE]}
+    }
+
+    result = _call(mock_datahub_client, urn=DATASET_URN, columns=["amount"])
+
+    field_profiles = result["data"]["profiles"][0]["fieldProfiles"]
+    assert [fp["fieldPath"] for fp in field_profiles] == ["amount"]
+
+
+def test_unknown_column_yields_no_field_profiles(mock_datahub_client):
+    """Filtering on a column that was not profiled is empty, not an error.
+
+    clean_gql_response drops empty collections, so the key is absent rather
+    than present-and-empty.
+    """
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": [PROFILE]}
+    }
+
+    result = _call(mock_datahub_client, urn=DATASET_URN, columns=["does_not_exist"])
+
+    assert result["success"] is True
+    assert not result["data"]["profiles"][0].get("fieldProfiles")
+
+
+def test_filtering_does_not_mutate_the_response(mock_datahub_client):
+    """Column filtering must not corrupt the caller's profile object."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": [PROFILE]}
+    }
+
+    _call(mock_datahub_client, urn=DATASET_URN, columns=["amount"])
+
+    assert [fp["fieldPath"] for fp in PROFILE["fieldProfiles"]] == [
+        "user_id",
+        "amount",
+    ]
+
+
+def test_limit_is_clamped_to_max(mock_datahub_client):
+    """An oversized limit is clamped rather than rejected."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": [PROFILE]}
+    }
+
+    _call(mock_datahub_client, urn=DATASET_URN, limit=999)
+
+    variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs["variables"]
+    assert variables["limit"] == MAX_LIMIT
+
+
+def test_time_range_is_forwarded(mock_datahub_client):
+    """Explicit time bounds reach the GraphQL query."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": [PROFILE]}
+    }
+
+    _call(
+        mock_datahub_client,
+        urn=DATASET_URN,
+        start_time_millis=1717000000000,
+        end_time_millis=1717200000000,
+    )
+
+    variables = mock_datahub_client._graph.execute_graphql.call_args.kwargs["variables"]
+    assert variables["startTimeMillis"] == 1717000000000
+    assert variables["endTimeMillis"] == 1717200000000
+
+
+def test_unprofiled_dataset_is_a_success_with_guidance(mock_datahub_client):
+    """No profiles is a valid answer, and the message says why that happens."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "dataset": {"urn": DATASET_URN, "datasetProfiles": []}
+    }
+
+    result = _call(mock_datahub_client, urn=DATASET_URN)
+
+    assert result["success"] is True
+    assert result["data"]["count"] == 0
+    assert "Profiling may not be enabled" in result["message"]
+
+
+def test_missing_dataset_raises(mock_datahub_client):
+    """A URN that resolves to nothing is an error, not an empty profile list."""
+    mock_datahub_client._graph.execute_graphql.return_value = {"dataset": None}
+
+    with pytest.raises(ValueError, match="Dataset not found"):
+        _call(mock_datahub_client, urn=DATASET_URN)
+
+
+def test_empty_urn_rejected_before_graphql(mock_datahub_client):
+    """Bad input never reaches DataHub."""
+    with pytest.raises(ValueError, match="urn cannot be empty"):
+        _call(mock_datahub_client, urn="")
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+def test_graphql_error_is_wrapped_with_context(mock_datahub_client):
+    """Transport errors surface the dataset URN so the caller can act on it."""
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception("boom")
+
+    with pytest.raises(RuntimeError, match=re.escape(DATASET_URN)):
+        _call(mock_datahub_client, urn=DATASET_URN)


### PR DESCRIPTION
## Summary

Exposes DataHub's dataset profile timeseries aspect through MCP: row count, column count, size, and per-column statistics (null rate, cardinality, min/max/mean/median/stdev, sample values).

The server can currently describe a dataset's *shape* — schema, lineage, assertions — but not its *contents*. That gap matters for debugging. Questions like "did this column start going null?" or "did row counts drop after Tuesday?" are answerable from metadata DataHub already stores, but there was no way to reach it from an agent.

## Design notes

- **Read-only**, tagged `@read_only` so clients may call it autonomously.
- **Optional `columns` filter.** A full profile of a several-hundred-column table is a large response, so callers can request only the columns they care about. Filtering happens after the fetch and returns a shallow copy, leaving the response object untouched.
- **Optional time bounds and `limit`** (default 1, clamped to 10) so a caller can compare a statistic across snapshots rather than only reading the latest.
- **Absent profiles are not an error.** Profiling is opt-in per ingestion recipe, so a dataset without profiles returns an empty result whose message explains why, rather than raising.

## Testing

- 10 unit tests covering filtering, clamping, time bounds, the unprofiled case, and error paths.
- Full suite green locally: 509 passed.
- `make lint-check` clean (ruff format, ruff check, mypy).
- The GraphQL query was executed against a live DataHub OSS instance to confirm the schema accepts it, including the `Long` time-bound arguments.

## Notes for reviewers

`tests/conftest.py` needed three lines to register the new module in the `datahub_integrations` compatibility shim, following the existing pattern.

Since `mcp_server.py` is kept in sync across two repositories, the registration line there will need mirroring.