### PR TITLE
feat(tools): add raise_incident / update_incident_status mutation tools (gated by TOOLS_IS_MUTATION_ENABLED)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Update, append to, or remove descriptions for entities or schema fields. Support
 
 Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types.
 
+`raise_incident`
+
+Raise a native DataHub incident on an asset. The incident appears on the asset's Incidents tab and contributes to its health signals. Supports CRITICAL, HIGH, MEDIUM, and LOW priorities.
+
+`update_incident_status`
+
+Update the status of an existing incident (ACTIVE or RESOLVED), with an optional message describing the change. Useful for resolving incidents once the underlying issue is fixed.
+
 ### User Tools
 
 These tools provide information about the authenticated user. Enabled via `TOOLS_IS_USER_ENABLED=true`.

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -71,6 +71,7 @@ from .tools.documents import grep_documents, search_documents
 from .tools.domains import remove_domains, set_domains
 from .tools.entities import get_entities, list_schema_fields
 from .tools.get_me import get_me
+from .tools.incidents import raise_incident, update_incident_status
 from .tools.lineage import (  # noqa: F401 (re-exported for backward compat)
     AssetLineageAPI,
     AssetLineageDirective,
@@ -261,6 +262,15 @@ def register_mutation_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None
     _register_tool(mcp_instance, "add_structured_properties", add_structured_properties)
     _register_tool(
         mcp_instance, "remove_structured_properties", remove_structured_properties
+    )
+    _register_tool(
+        mcp_instance, "raise_incident", raise_incident, tags={ToolType.MUTATION.value}
+    )
+    _register_tool(
+        mcp_instance,
+        "update_incident_status",
+        update_incident_status,
+        tags={ToolType.MUTATION.value},
     )
 
     # Register save_document tool (only if enabled via environment variable)

--- a/src/mcp_server_datahub/tools/__init__.py
+++ b/src/mcp_server_datahub/tools/__init__.py
@@ -6,6 +6,7 @@ from .documents import grep_documents, search_documents
 from .domains import remove_domains, set_domains
 from .entities import get_entities, list_schema_fields
 from .get_me import get_me
+from .incidents import raise_incident, update_incident_status
 from .lineage import get_lineage, get_lineage_paths_between
 from .owners import add_owners, remove_owners
 from .search import enhanced_search, search
@@ -32,6 +33,7 @@ __all__ = [
     "get_me",
     "grep_documents",
     "list_schema_fields",
+    "raise_incident",
     "remove_domains",
     "remove_glossary_terms",
     "remove_owners",
@@ -41,4 +43,5 @@ __all__ = [
     "search_documents",
     "set_domains",
     "update_description",
+    "update_incident_status",
 ]

--- a/src/mcp_server_datahub/tools/incidents.py
+++ b/src/mcp_server_datahub/tools/incidents.py
@@ -1,0 +1,193 @@
+"""Incident management tools for DataHub MCP server."""
+
+import logging
+from typing import Optional
+
+from .. import graphql_helpers
+
+logger = logging.getLogger(__name__)
+
+VALID_PRIORITIES = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+VALID_STATES = {"ACTIVE", "RESOLVED"}
+
+
+def raise_incident(
+    dataset_urn: str,
+    title: str,
+    description: str,
+    priority: Optional[str] = None,
+) -> dict:
+    """Raise a native DataHub incident on an asset.
+
+    The incident appears on the asset's Incidents tab in the DataHub UI and
+    contributes to the asset's health signals. Use this to flag operational
+    problems (bad data, broken pipelines, freshness issues) so that downstream
+    consumers and owners are alerted.
+
+    Args:
+        dataset_urn: URN of the asset to raise the incident on
+                     (e.g., "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)").
+                     Datasets are the most common target, but any asset that
+                     supports incidents (dashboards, charts, data flows, etc.) works.
+        title: Short human-readable title for the incident.
+        description: Longer description of the problem, e.g. what was observed
+                     and what the suspected root cause is. Supports markdown.
+        priority: Optional incident priority. One of: CRITICAL, HIGH, MEDIUM, LOW.
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - message: Success or error message
+        - incident_urn: URN of the newly created incident
+
+    Examples:
+        # Raise a high-priority incident on a dataset
+        raise_incident(
+            dataset_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)",
+            title="Null user_ids in users table",
+            description="~14% of rows loaded after 2024-05-01 have NULL user_id.",
+            priority="HIGH"
+        )
+
+        # Raise an incident without an explicit priority
+        raise_incident(
+            dataset_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)",
+            title="Orders table is stale",
+            description="No new partitions have landed in 2 days."
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not dataset_urn:
+        raise ValueError("dataset_urn cannot be empty")
+    if not title:
+        raise ValueError("title cannot be empty")
+
+    incident_input: dict = {
+        "type": "OPERATIONAL",
+        "title": title,
+        "description": description,
+        "resourceUrn": dataset_urn,
+    }
+
+    if priority is not None:
+        normalized_priority = priority.upper()
+        if normalized_priority not in VALID_PRIORITIES:
+            raise ValueError(
+                f"priority must be one of {sorted(VALID_PRIORITIES)}, got {priority!r}"
+            )
+        incident_input["priority"] = normalized_priority
+
+    mutation = """
+        mutation raiseIncident($input: RaiseIncidentInput!) {
+            raiseIncident(input: $input)
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables={"input": incident_input},
+            operation_name="raiseIncident",
+        )
+
+        incident_urn = result.get("raiseIncident")
+        if not incident_urn:
+            raise RuntimeError(
+                "Failed to raise incident - operation did not return an incident URN"
+            )
+
+        return {
+            "success": True,
+            "message": f"Successfully raised incident on {dataset_urn}",
+            "incident_urn": incident_urn,
+        }
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error raising incident: {str(e)}") from e
+
+
+def update_incident_status(
+    incident_urn: str,
+    state: str,
+    message: Optional[str] = None,
+) -> dict:
+    """Update the status of an existing DataHub incident.
+
+    Use this to resolve an incident once the underlying problem is fixed, or to
+    re-open a previously resolved incident. The status change (and optional
+    message) is reflected on the asset's Incidents tab in the DataHub UI.
+
+    Args:
+        incident_urn: URN of the incident to update
+                      (e.g., "urn:li:incident:8ea4a5a0-...").
+                      Incident URNs are returned by raise_incident and can also
+                      be found via the asset's incidents in the UI.
+        state: New incident state. One of: ACTIVE, RESOLVED.
+        message: Optional message describing the status change, e.g. how the
+                 incident was resolved.
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - message: Success or error message
+
+    Examples:
+        # Resolve an incident with a closing message
+        update_incident_status(
+            incident_urn="urn:li:incident:8ea4a5a0-2b96-4b28-9a3c-1a3d5e2f0c11",
+            state="RESOLVED",
+            message="Backfilled missing partitions; upstream job fixed."
+        )
+
+        # Re-open an incident
+        update_incident_status(
+            incident_urn="urn:li:incident:8ea4a5a0-2b96-4b28-9a3c-1a3d5e2f0c11",
+            state="ACTIVE"
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not incident_urn:
+        raise ValueError("incident_urn cannot be empty")
+
+    normalized_state = state.upper() if state else ""
+    if normalized_state not in VALID_STATES:
+        raise ValueError(f"state must be one of {sorted(VALID_STATES)}, got {state!r}")
+
+    status_input: dict = {"state": normalized_state}
+    if message is not None:
+        status_input["message"] = message
+
+    mutation = """
+        mutation updateIncidentStatus($urn: String!, $input: IncidentStatusInput!) {
+            updateIncidentStatus(urn: $urn, input: $input)
+        }
+    """
+
+    try:
+        result = graphql_helpers.execute_graphql(
+            client._graph,
+            query=mutation,
+            variables={"urn": incident_urn, "input": status_input},
+            operation_name="updateIncidentStatus",
+        )
+
+        success = result.get("updateIncidentStatus", False)
+        if success:
+            return {
+                "success": True,
+                "message": f"Successfully updated incident {incident_urn} to {normalized_state}",
+            }
+        else:
+            raise RuntimeError(
+                "Failed to update incident status - operation returned false"
+            )
+
+    except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
+        raise RuntimeError(f"Error updating incident status: {str(e)}") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ if using_oss:
     documents_module = sys.modules["mcp_server_datahub.tools.documents"]
     domains_module = sys.modules["mcp_server_datahub.tools.domains"]
     get_me_module = sys.modules["mcp_server_datahub.tools.get_me"]
+    incidents_module = sys.modules["mcp_server_datahub.tools.incidents"]
     owners_module = sys.modules["mcp_server_datahub.tools.owners"]
     save_document_module = sys.modules["mcp_server_datahub.tools.save_document"]
     structured_properties_module = sys.modules[
@@ -139,6 +140,7 @@ if using_oss:
     tools_module.domains = domains_module  # type: ignore[attr-defined]
     tools_module.entities = entities_module  # type: ignore[attr-defined]
     tools_module.get_me = get_me_module  # type: ignore[attr-defined]
+    tools_module.incidents = incidents_module  # type: ignore[attr-defined]
     tools_module.lineage = lineage_module  # type: ignore[attr-defined]
     tools_module.owners = owners_module  # type: ignore[attr-defined]
     tools_module.save_document = save_document_module  # type: ignore[attr-defined]
@@ -156,6 +158,7 @@ if using_oss:
     sys.modules["datahub_integrations.mcp.tools.domains"] = domains_module
     sys.modules["datahub_integrations.mcp.tools.entities"] = entities_module
     sys.modules["datahub_integrations.mcp.tools.get_me"] = get_me_module
+    sys.modules["datahub_integrations.mcp.tools.incidents"] = incidents_module
     sys.modules["datahub_integrations.mcp.tools.lineage"] = lineage_module
     sys.modules["datahub_integrations.mcp.tools.owners"] = owners_module
     sys.modules["datahub_integrations.mcp.tools.save_document"] = save_document_module

--- a/tests/test_mcp/tools/test_incidents.py
+++ b/tests/test_mcp/tools/test_incidents.py
@@ -1,0 +1,326 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_integrations.mcp.tools.incidents import (
+    raise_incident,
+    update_incident_status,
+)
+
+
+@pytest.fixture
+def mock_datahub_client():
+    """Fixture for mocking DataHubClient."""
+    mock_client = Mock()
+    mock_graph = Mock()
+    mock_client._graph = mock_graph
+    return mock_client
+
+
+# Tests for raise_incident
+
+
+def test_raise_incident_success(mock_datahub_client):
+    """Test raising an incident with a priority."""
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
+    incident_urn = "urn:li:incident:8ea4a5a0-2b96-4b28-9a3c-1a3d5e2f0c11"
+
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": incident_urn
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = raise_incident(
+            dataset_urn=dataset_urn,
+            title="Null user_ids in users table",
+            description="~14% of rows have NULL user_id.",
+            priority="HIGH",
+        )
+
+    assert result["success"] is True
+    assert result["incident_urn"] == incident_urn
+    assert dataset_urn in result["message"]
+
+    assert mock_datahub_client._graph.execute_graphql.call_count == 1
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[0]
+    variables = mutation_call.kwargs["variables"]
+
+    assert variables["input"]["type"] == "OPERATIONAL"
+    assert variables["input"]["resourceUrn"] == dataset_urn
+    assert variables["input"]["title"] == "Null user_ids in users table"
+    assert variables["input"]["description"] == "~14% of rows have NULL user_id."
+    assert variables["input"]["priority"] == "HIGH"
+
+
+def test_raise_incident_without_priority(mock_datahub_client):
+    """Test raising an incident without a priority omits the field."""
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)"
+
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": "urn:li:incident:test"
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = raise_incident(
+            dataset_urn=dataset_urn,
+            title="Orders table is stale",
+            description="No new partitions in 2 days.",
+        )
+
+    assert result["success"] is True
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[0]
+    variables = mutation_call.kwargs["variables"]
+
+    assert "priority" not in variables["input"]
+
+
+def test_raise_incident_lowercase_priority_normalized(mock_datahub_client):
+    """Test that a lowercase priority is normalized to uppercase."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": "urn:li:incident:test"
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = raise_incident(
+            dataset_urn="urn:li:dataset:test",
+            title="Test incident",
+            description="Test description",
+            priority="critical",
+        )
+
+    assert result["success"] is True
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[0]
+    variables = mutation_call.kwargs["variables"]
+
+    assert variables["input"]["priority"] == "CRITICAL"
+
+
+def test_raise_incident_invalid_priority(mock_datahub_client):
+    """Test that an invalid priority raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="priority must be one of"):
+            raise_incident(
+                dataset_urn="urn:li:dataset:test",
+                title="Test incident",
+                description="Test description",
+                priority="URGENT",
+            )
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+def test_raise_incident_empty_dataset_urn(mock_datahub_client):
+    """Test that empty dataset_urn raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="dataset_urn cannot be empty"):
+            raise_incident(
+                dataset_urn="",
+                title="Test incident",
+                description="Test description",
+            )
+
+
+def test_raise_incident_empty_title(mock_datahub_client):
+    """Test that empty title raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="title cannot be empty"):
+            raise_incident(
+                dataset_urn="urn:li:dataset:test",
+                title="",
+                description="Test description",
+            )
+
+
+def test_raise_incident_missing_urn_in_response(mock_datahub_client):
+    """Test handling of mutation response without an incident URN."""
+    mock_datahub_client._graph.execute_graphql.return_value = {"raiseIncident": None}
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(
+            RuntimeError, match="did\\ not\\ return\\ an\\ incident\\ URN"
+        ):
+            raise_incident(
+                dataset_urn="urn:li:dataset:test",
+                title="Test incident",
+                description="Test description",
+            )
+
+
+def test_raise_incident_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL exceptions during mutation."""
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception("Network error")
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Error raising incident"):
+            raise_incident(
+                dataset_urn="urn:li:dataset:test",
+                title="Test incident",
+                description="Test description",
+            )
+
+
+# Tests for update_incident_status
+
+
+def test_update_incident_status_resolved(mock_datahub_client):
+    """Test resolving an incident with a message."""
+    incident_urn = "urn:li:incident:8ea4a5a0-2b96-4b28-9a3c-1a3d5e2f0c11"
+
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "updateIncidentStatus": True
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_incident_status(
+            incident_urn=incident_urn,
+            state="RESOLVED",
+            message="Backfilled missing partitions.",
+        )
+
+    assert result["success"] is True
+    assert "RESOLVED" in result["message"]
+
+    assert mock_datahub_client._graph.execute_graphql.call_count == 1
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[0]
+    variables = mutation_call.kwargs["variables"]
+
+    assert variables["urn"] == incident_urn
+    assert variables["input"]["state"] == "RESOLVED"
+    assert variables["input"]["message"] == "Backfilled missing partitions."
+
+
+def test_update_incident_status_active_without_message(mock_datahub_client):
+    """Test re-opening an incident without a message omits the field."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "updateIncidentStatus": True
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_incident_status(
+            incident_urn="urn:li:incident:test",
+            state="ACTIVE",
+        )
+
+    assert result["success"] is True
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[0]
+    variables = mutation_call.kwargs["variables"]
+
+    assert variables["input"]["state"] == "ACTIVE"
+    assert "message" not in variables["input"]
+
+
+def test_update_incident_status_lowercase_state_normalized(mock_datahub_client):
+    """Test that a lowercase state is normalized to uppercase."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "updateIncidentStatus": True
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_incident_status(
+            incident_urn="urn:li:incident:test",
+            state="resolved",
+        )
+
+    assert result["success"] is True
+
+    mutation_call = mock_datahub_client._graph.execute_graphql.call_args_list[0]
+    variables = mutation_call.kwargs["variables"]
+
+    assert variables["input"]["state"] == "RESOLVED"
+
+
+def test_update_incident_status_invalid_state(mock_datahub_client):
+    """Test that an invalid state raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="state must be one of"):
+            update_incident_status(
+                incident_urn="urn:li:incident:test",
+                state="CLOSED",
+            )
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+def test_update_incident_status_empty_incident_urn(mock_datahub_client):
+    """Test that empty incident_urn raises ValueError."""
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="incident_urn cannot be empty"):
+            update_incident_status(incident_urn="", state="RESOLVED")
+
+
+def test_update_incident_status_graphql_failure(mock_datahub_client):
+    """Test handling of GraphQL mutation returning false."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "updateIncidentStatus": False
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(
+            RuntimeError, match="Failed\\ to\\ update\\ incident\\ status"
+        ):
+            update_incident_status(
+                incident_urn="urn:li:incident:test",
+                state="RESOLVED",
+            )
+
+
+def test_update_incident_status_graphql_exception(mock_datahub_client):
+    """Test handling of GraphQL exceptions during mutation."""
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "Authorization error"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="Error updating incident status"):
+            update_incident_status(
+                incident_urn="urn:li:incident:test",
+                state="RESOLVED",
+            )


### PR DESCRIPTION
## What

Adds two mutation tools that expose DataHub's native Incidents API to MCP agents:

- **`raise_incident(dataset_urn, title, description, priority=None)`** — raises a native incident on an asset via the `raiseIncident` GraphQL mutation (`type=OPERATIONAL`). The incident appears on the asset's Incidents tab and contributes to its health signals. `priority` is validated against `CRITICAL | HIGH | MEDIUM | LOW` and omitted from the mutation input when not provided. Returns the new incident URN.
- **`update_incident_status(incident_urn, state, message=None)`** — updates an incident via `updateIncidentStatus(urn, input: IncidentStatusInput)`. `state` is validated against `ACTIVE | RESOLVED`; `message` is optional.

Both tools are registered in `register_mutation_tools()` with the `mutation` tag and are only available when `TOOLS_IS_MUTATION_ENABLED=true` — the same gate as the existing tag/term/owner/domain mutations. No new environment variables or dependencies.

## Why

The server already gives agents everything they need to *diagnose* a data problem — search, lineage, schema, queries, assertions — but no way to *act* on the diagnosis. Its mutations stop at tags, terms, owners, domains, descriptions, and structured properties; DataHub's first-class incident primitive is not exposed. That means an agent that traces a broken pipeline through lineage cannot flag the affected asset for its human owners inside DataHub itself, and cannot close the incident after remediation. These two tools complete that loop with the platform's native incident lifecycle (raise → resolve/re-open), rather than approximating it with tags or description edits.

Mutation names and input shapes were verified against `datahub-graphql-core`'s `incident.graphql` (`raiseIncident(input: RaiseIncidentInput!): String`, `updateIncidentStatus(urn: String!, input: IncidentStatusInput!): Boolean`).

## Testing

- 15 new unit tests in `tests/test_mcp/tools/test_incidents.py`, mirroring the existing `test_tags.py` conventions (mocked `DataHubClient._graph.execute_graphql`, patched `graphql_helpers.get_datahub_client`): success paths, GraphQL variable shapes, enum validation and case normalization, omission of optional fields, empty-input `ValueError`s, mutation-returned-false and transport-exception `RuntimeError`s.
- Full suite: `uv run pytest tests/test_mcp/` — 514 passed.
- Lint/type: `make lint-check` clean (`ruff format --check`, `ruff check`, `mypy`).
- `tests/conftest.py` cross-repo compatibility shim extended to expose `tools.incidents` under the `datahub_integrations.mcp` namespace, matching the existing pattern for the other tool modules.
- README "Mutation Tools" section updated with both tools, matching the existing entry format.

## Breaking changes

None. Purely additive; tools are off by default (behind `TOOLS_IS_MUTATION_ENABLED`).

---

Built during the DataHub Agent Hackathon for the CASCADE project (autonomous data-incident responder): https://github.com/Biniyoyo/Cascade