### PR TITLE
fix(search): report when num_results is capped

### DIFF
--- a/src/mcp_server_datahub/tools/search.py
+++ b/src/mcp_server_datahub/tools/search.py
@@ -14,6 +14,10 @@ search_gql = (graphql_helpers.GQL_DIR / "search.gql").read_text()
 semantic_search_gql = (graphql_helpers.GQL_DIR / "semantic_search.gql").read_text()
 smart_search_gql = (graphql_helpers.GQL_DIR / "smart_search.gql").read_text()
 
+# Largest page the search tools will fetch. Requests above this are served at
+# this size, and the response says so via _searchLimitReached.
+MAX_SEARCH_RESULTS = 50
+
 
 def _search_implementation(
     query: str,
@@ -27,8 +31,10 @@ def _search_implementation(
     """Core search implementation that can use semantic, keyword, or ersatz_semantic search."""
     client = graphql_helpers.get_datahub_client()
 
-    # Cap num_results at 50 to prevent excessive requests
-    num_results = min(num_results, 50)
+    # Cap num_results to prevent excessive requests. The requested value is kept
+    # so the response can report that the page was served smaller than asked.
+    requested_num_results = num_results
+    num_results = min(num_results, MAX_SEARCH_RESULTS)
 
     parsed_filter = graphql_helpers.parse_filter_input(filter)
 
@@ -91,6 +97,19 @@ def _search_implementation(
         response.pop("searchResults", None)
         response.pop("count", None)
 
+    # Tell the caller when we served a smaller page than they asked for, so an
+    # agent can page through the rest instead of reading a truncated result set
+    # as the whole story. Mirrors _hybridSearchLimitReached in search_documents.
+    if requested_num_results > MAX_SEARCH_RESULTS and isinstance(response, dict):
+        response["_searchLimitReached"] = True
+        response["_searchMaxResults"] = MAX_SEARCH_RESULTS
+        logger.info(
+            "Search page size capped: requested num_results={} exceeds max of {}; "
+            "use offset to paginate",
+            requested_num_results,
+            MAX_SEARCH_RESULTS,
+        )
+
     return graphql_helpers.clean_gql_response(response)
 
 
@@ -136,6 +155,10 @@ def enhanced_search(
 
     PAGINATION:
     - num_results: Number of results to return per page (max: 50)
+    - Asking for more than 50 returns 50, and the response carries
+      `_searchLimitReached: true` — page through the rest with offset rather
+      than treating those 50 as the complete result set. Compare `total` to the
+      number of results returned to see how much is left.
     - offset: Starting position in results (default: 0)
     - Examples:
       * First page: offset=0, num_results=10
@@ -213,6 +236,10 @@ def search(
 
     PAGINATION:
     - num_results: Number of results to return per page (max: 50)
+    - Asking for more than 50 returns 50, and the response carries
+      `_searchLimitReached: true` — page through the rest with offset rather
+      than treating those 50 as the complete result set. Compare `total` to the
+      number of results returned to see how much is left.
     - offset: Starting position in results (default: 0)
     - Examples:
       * First page: offset=0, num_results=10

--- a/tests/test_mcp/test_search_result_limit.py
+++ b/tests/test_mcp/test_search_result_limit.py
@@ -1,0 +1,98 @@
+"""Tests that search reports when it serves a smaller page than requested."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_integrations.mcp.tools.search import (
+    MAX_SEARCH_RESULTS,
+    _search_implementation,
+)
+
+
+@pytest.fixture
+def mock_client():
+    client = Mock()
+    client._graph = Mock()
+    return client
+
+
+def _gql_response(num_results: int) -> dict:
+    """A search response shaped like GMS returns it, for a catalog of 1232 entities."""
+    returned = min(num_results, MAX_SEARCH_RESULTS)
+    return {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": returned,
+            "total": 1232,
+            "searchResults": [
+                {
+                    "entity": {
+                        "urn": f"urn:li:dataset:(urn:li:dataPlatform:snowflake,db.t{i},PROD)"
+                    }
+                }
+                for i in range(returned)
+            ],
+        }
+    }
+
+
+def _run(mock_client, num_results: int) -> dict:
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_client,
+        ),
+        patch("datahub_integrations.mcp.graphql_helpers.get_mcp_context"),
+        patch("datahub_integrations.mcp.graphql_helpers.execute_graphql") as mock_gql,
+    ):
+        mock_gql.return_value = _gql_response(num_results)
+        return _search_implementation(query="*", filter=None, num_results=num_results)
+
+
+class TestSearchResultLimit:
+    def test_flags_the_response_when_the_page_is_capped(self, mock_client):
+        result = _run(mock_client, num_results=200)
+
+        assert result["_searchLimitReached"] is True
+        assert result["_searchMaxResults"] == MAX_SEARCH_RESULTS
+        assert len(result["searchResults"]) == MAX_SEARCH_RESULTS
+        # total still shows how much the caller has not seen
+        assert result["total"] == 1232
+
+    def test_requests_within_the_limit_are_not_flagged(self, mock_client):
+        result = _run(mock_client, num_results=10)
+
+        assert "_searchLimitReached" not in result
+        assert "_searchMaxResults" not in result
+
+    def test_a_request_of_exactly_the_limit_is_not_flagged(self, mock_client):
+        result = _run(mock_client, num_results=MAX_SEARCH_RESULTS)
+
+        assert "_searchLimitReached" not in result
+        assert len(result["searchResults"]) == MAX_SEARCH_RESULTS
+
+    def test_the_capped_value_is_what_gets_sent_to_gms(self, mock_client):
+        with (
+            patch(
+                "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+                return_value=mock_client,
+            ),
+            patch("datahub_integrations.mcp.graphql_helpers.get_mcp_context"),
+            patch(
+                "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+            ) as mock_gql,
+        ):
+            mock_gql.return_value = _gql_response(200)
+            _search_implementation(query="*", filter=None, num_results=200)
+
+            assert mock_gql.call_args.kwargs["variables"]["count"] == MAX_SEARCH_RESULTS
+
+    def test_facet_only_requests_still_drop_results_and_are_not_flagged(
+        self, mock_client
+    ):
+        """num_results=0 is the facet-exploration mode and is not a capped page."""
+        result = _run(mock_client, num_results=0)
+
+        assert "searchResults" not in result
+        assert "_searchLimitReached" not in result


### PR DESCRIPTION
### What

`search()` and `enhanced_search()` cap `num_results` at 50, but nothing in the response tells the caller that its own parameter was changed. This adds `_searchLimitReached` / `_searchMaxResults` to the response when — and only when — the request was capped, following the convention `search_documents` already uses for its own cap.

### Why

I hit this building an agent that remediates metadata debt over this server. It called `search(query="*", num_results=200)`, got 50 results back, and concluded it had seen the whole catalog. It had seen **19 of 69 datasets** — the other 31 results on that page were dataProducts, containers and corpUsers — and then reported "0 findings remaining" over a quarter of the catalog. Every number it produced was wrong, and nothing in the exchange looked like an error.

The information needed to catch this is technically present (`total` is returned, and `count` reflects the served size), but it requires the caller to notice that the `count` it got back differs from the `num_results` it sent. In practice an LLM caller reads 50 plausible results and moves on. The docstring does say `max: 50`, but prose in a docstring is a suggestion to a model, not a signal it can check after the fact.

This is exactly the situation `_search_documents_hybrid` already handles for its own limit:

```python
if hit_fetch_limit:
    merged["_hybridSearchLimitReached"] = True
    merged["_hybridSearchMaxResults"] = MAX_HYBRID_FETCH_RESULTS
```

The most-used tool in the server caps the same way and stays silent. This PR makes the two consistent.

### What changed

- Extract the literal `50` into `MAX_SEARCH_RESULTS`.
- Keep the requested value; if it exceeded the max, add `_searchLimitReached: true` and `_searchMaxResults: 50` to the response and log at info.
- Document the behaviour in both tool docstrings, pointing at `offset` and `total`.

Additive and non-breaking: identical rows come back, plus one marker on capped requests. `num_results=0` (facet-only) is unaffected.

### Verification

Against a live DataHub (OSS quickstart v1.5.0.6, 1232 entities):

```
num_results=200  returned=50  count=50 total=1232 flags={'_searchLimitReached': True, '_searchMaxResults': 50}
num_results=50   returned=50  count=50 total=1232 flags=none
num_results=10   returned=10  count=10 total=1232 flags=none
```

5 new unit tests in `tests/test_mcp/test_search_result_limit.py` (no live instance needed), covering: capped request is flagged, in-limit and exactly-at-limit are not, the capped value is what reaches GMS, and facet-only mode is unaffected.

Full gate green: `ruff format` clean, `ruff check` clean, `mypy` clean, `pytest` 506 passed / 39 skipped.

### An alternative you may prefer

The stronger fix is to declare the bound in the signature so it lands in the tool's JSON schema, where the agent can see it *before* calling:

```python
num_results: Annotated[int, Field(ge=0, le=50)] = 10
```

Then out-of-range calls fail validation with a clear message instead of being coerced, and the `maximum: 50` constraint shows up in the tool definition the model reads. I did not do that here because it turns currently-succeeding calls into errors. Happy to switch this PR to that approach if you'd rather have it.

### Related, not fixed here

`num_results=-5` currently returns exactly 1 result (`min(-5, 50)` → `-5`, then `max(-5, 1)` → 1) with no error. Same class of silent coercion. Left out to keep this PR to one behaviour; glad to follow up if useful.
