### PR TITLE
Expose Dataset.externalUrl through get_entities

### DIFF
--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -519,6 +519,7 @@ fragment entityPreview on Entity {
         properties {
             name
             description
+            externalUrl
             customProperties {
                 key
                 value

--- a/tests/test_mcp/test_dataset_external_url.py
+++ b/tests/test_mcp/test_dataset_external_url.py
@@ -1,0 +1,98 @@
+"""Regression tests for Dataset.externalUrl in the entity_details projection.
+
+`externalUrl` is populated on Dataset by ingestion sources that know where the
+entity's source lives — the dbt source derives it from `git_info`, and pins it
+to a commit when `branch` is set to a SHA. It is the only field carrying a
+resolvable link from a dataset to the code that produces it.
+
+It was requested for CorpGroup, Dashboard, Chart, Assertion and Document but not
+for Dataset, so `get_entities` returned datasets without a source link even when
+GMS held a value. These tests pin it into the projection so that cannot recur.
+
+They assert against the GraphQL document rather than a live instance, so they
+need no credentials and fail for the right reason: a projection regression,
+rather than an unreachable environment.
+
+`entity_details.gql` contains several `... on Dataset` inline fragments for
+different purposes. The one `get_entities` resolves through is the one in
+`fragment entityPreview`, so these tests target that fragment by name — a test
+scoped to "anywhere in the file" would pass on an unrelated occurrence.
+"""
+
+from mcp_server_datahub.graphql_helpers import GQL_DIR
+
+ENTITY_DETAILS = (GQL_DIR / "entity_details.gql").read_text()
+
+PREVIEW_FRAGMENT = "entityPreview"
+
+
+def _balanced_block(document: str, opening: str, search_from: int = 0) -> str:
+    """Return the brace-balanced body that follows `opening`.
+
+    Regex cannot do this — the blocks nest — so this tracks depth. Raises rather
+    than returning a partial body, so a malformed document fails loudly instead
+    of silently satisfying an assertion.
+    """
+    start = document.index(opening, search_from) + len(opening)
+    depth = 1
+    for index in range(start, len(document)):
+        char = document[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return document[start:index]
+    raise AssertionError(f"unterminated block after {opening!r}")
+
+
+def _dataset_properties_in_preview() -> str:
+    """The body of Dataset.properties inside `fragment entityPreview`."""
+    preview = _balanced_block(ENTITY_DETAILS, f"fragment {PREVIEW_FRAGMENT} on Entity {{")
+    dataset = _balanced_block(preview, "... on Dataset {")
+    return _balanced_block(dataset, "properties {")
+
+
+class TestDatasetExternalUrl:
+    def test_dataset_properties_requests_external_url(self) -> None:
+        """The field get_entities depends on is actually requested."""
+        properties = _dataset_properties_in_preview()
+        assert "externalUrl" in properties, (
+            f"Dataset.properties in fragment {PREVIEW_FRAGMENT} no longer requests "
+            "externalUrl. get_entities will return datasets without a source link "
+            "even when GMS holds one."
+        )
+
+    def test_sibling_fields_still_present(self) -> None:
+        """Guards against the block being emptied rather than the field added.
+
+        Without this, deleting the whole properties body would leave the test
+        above failing for a misleading reason.
+        """
+        properties = _dataset_properties_in_preview()
+        for field in ("name", "description", "customProperties"):
+            assert field in properties, f"Dataset.properties lost {field}"
+
+    def test_dataset_is_not_an_exception_among_linkable_entities(self) -> None:
+        """Dataset sits alongside the other entity types carrying a source link.
+
+        Asserted as a subset so adding externalUrl to a further type does not
+        fail here, while removing it from Dataset does.
+        """
+        preview = _balanced_block(ENTITY_DETAILS, f"fragment {PREVIEW_FRAGMENT} on Entity {{")
+        exposing = set()
+        cursor = 0
+        while True:
+            marker = "... on "
+            try:
+                at = preview.index(marker, cursor)
+            except ValueError:
+                break
+            type_name = preview[at + len(marker) : preview.index(" {", at)]
+            body = _balanced_block(preview, f"... on {type_name} {{", at)
+            if "externalUrl" in body:
+                exposing.add(type_name)
+            cursor = at + len(marker)
+
+        missing = {"Dashboard", "Chart", "Dataset"} - exposing
+        assert not missing, f"entity types no longer requesting externalUrl: {missing}"


### PR DESCRIPTION
`externalUrl` is requested for `CorpGroup`, `Dashboard`, `Chart`, `Assertion` and `Document` in the `entityPreview` fragment, but not for `Dataset`. GMS holds a value for datasets — the dbt source derives one from `git_info` — so `get_entities` returns a dataset with its source link dropped at the MCP boundary.

## Reproduction

Against a local `datahub docker quickstart` (GMS `v1.5.0.6`) with a dbt project ingested:

```console
$ # what GMS holds
$ curl -s localhost:8080/api/graphql -d '{"query":"{ dataset(urn:\"...jaffle_shop.main.customers,PROD\") { properties { externalUrl } } }"}'
"externalUrl": "https://github.com/dbt-labs/jaffle_shop_duckdb/blob/36bde6cba69d962b83be1d52fc65a0dce1cb4ebb/models/customers.sql"

$ # what get_entities returns
properties keys: ['customProperties', 'description', 'name']
externalUrl:     absent
```

## Why it is not recoverable another way

`customProperties.dbt_file_path` is projected, so the path is reachable — but it is relative to the dbt project. Nothing else in the projection anchors it.

Every property returned for a dbt dataset whose project sits in a `dbt/` subdirectory:

```
dbt_file_path      models/curated/game_events.sql
dbt_package_name   transfermarkt_datasets
dbt_unique_id      model.transfermarkt_datasets.game_events
language           sql
manifest_adapter   duckdb
manifest_schema    https://schemas.getdbt.com/dbt/manifest/v12.json
manifest_version   1.12.0
materialization    table
node_type          model
```

There is no repository (`dbt_package_name` is the dbt package, not the GitHub repo), no commit, and no project offset from the repository root. A consumer therefore cannot build a link, and cannot derive the repository-relative path either — the source's `url_subdir` appears nowhere else.

The nested case makes the difference concrete:

```
dbt_file_path   models/curated/game_events.sql                          project-relative
externalUrl     .../blob/59fa295c.../dbt/models/curated/game_events.sql repository-relative
```

This does not affect whoever configured ingestion — they already know the repository and commit. It affects an agent consuming an instance it did not configure, which is the usual MCP case.

## Change

One line in `entity_details.gql`, matching how `Dashboard` and `Chart` request the field in the same fragment:

```diff
 fragment entityPreview on Entity {
         properties {
             name
             description
+            externalUrl
             customProperties {
```

## Verification

`get_entities` after the change, for a root-level and a nested dbt project:

```
customers    https://github.com/dbt-labs/jaffle_shop_duckdb/blob/36bde6cb.../models/customers.sql
game_events  https://github.com/dcaribou/transfermarkt-datasets/blob/59fa295c.../dbt/models/curated/game_events.sql
```

Both commit-pinned, because `git_info.branch` accepts a SHA.

## Tests

`tests/test_mcp/test_dataset_external_url.py` asserts against the GraphQL document rather than a live instance, so it needs no credentials and fails on a projection regression rather than an unreachable environment.

`entity_details.gql` contains several `... on Dataset` inline fragments; the tests target `entityPreview` by name, since a file-wide assertion would pass on an unrelated occurrence.

Confirmed failing before the change and passing after. The 7 pre-existing failures in `test_document_tools_middleware.py` and `test_version_requirements.py` are unchanged on a clean tree.

## Notes

- Ingestion used CLI `1.6.0.15` against GMS `v1.5.0.6`; the client warns about the skew. It does not affect this result — the field is populated and served correctly by GMS.
- A discrete repository / commit / subdirectory field would be cleaner for consumers than a URL to parse, but `externalUrl` is what exists today and it carries all three.