### PR TITLE
docs: clarify entity_type filter — "report" isn't valid, BI reports are typed dataset

### DIFF
--- a/src/mcp_server_datahub/search_filter_parser.py
+++ b/src/mcp_server_datahub/search_filter_parser.py
@@ -97,9 +97,11 @@ FILTER SYNTAX (SQL-like WHERE clause):
 
     SUPPORTED FILTER FIELDS:
     - entity_type: dataset, dashboard, chart, corp_user, corp_group, dataProduct, etc.
-      ("report" is not a valid entity_type -- report/dashboard-style artifacts from BI
-      tools such as PowerBI, Tableau, and Looker are commonly indexed as entity_type =
-      dataset in DataHub; check entity_subtype for a finer-grained distinction)
+      ("report" is not a valid entity_type -- the visual report/dashboard object from
+      BI tools like PowerBI, Tableau, and Looker is entity_type = dashboard, but the
+      underlying semantic model/view feeding it (e.g. a PowerBI dataset, Looker
+      Explore/View, Tableau data source) is typically its own entity_type = dataset;
+      search both if one comes up empty)
     - entity_subtype (or subtype): Table, View, Model, etc.
     - platform: snowflake, bigquery, looker, tableau, etc.
     - domain: full URN required, e.g. urn:li:domain:marketing

--- a/src/mcp_server_datahub/search_filter_parser.py
+++ b/src/mcp_server_datahub/search_filter_parser.py
@@ -97,6 +97,9 @@ FILTER SYNTAX (SQL-like WHERE clause):
 
     SUPPORTED FILTER FIELDS:
     - entity_type: dataset, dashboard, chart, corp_user, corp_group, dataProduct, etc.
+      ("report" is not a valid entity_type -- report/dashboard-style artifacts from BI
+      tools such as PowerBI, Tableau, and Looker are commonly indexed as entity_type =
+      dataset in DataHub; check entity_subtype for a finer-grained distinction)
     - entity_subtype (or subtype): Table, View, Model, etc.
     - platform: snowflake, bigquery, looker, tableau, etc.
     - domain: full URN required, e.g. urn:li:domain:marketing


### PR DESCRIPTION
## What

One-line addition to `FILTER_DOCS` in `search_filter_parser.py` clarifying that
`entity_type = report` is not a valid filter value, and distinguishing the two real
entity types that show up around BI report/dashboard artifacts: the visual
report/dashboard object itself (`entity_type = dashboard`) versus the underlying
semantic model/view feeding it — e.g. a PowerBI dataset, a Looker Explore/View, a
Tableau data source — which is typically its own `entity_type = dataset`.

## Why

Hit this firsthand building an agent against DataHub's real showcase-ecommerce
datapack (for the DataHub Agent Hackathon). Given an incident report mentioning a
BI dashboard, an LLM resolving the target entity guessed `entity_type = report` — a
reasonable-sounding but invalid value — got zero search results, and burned a couple
of retries before recovering. Even once using valid types, it's easy to search only
`dashboard` and miss the separate `dataset`-typed semantic-model entity (or vice
versa) since both exist side by side for the same BI tool. Confirmed this pattern
directly against real lineage data in the showcase-ecommerce datapack (e.g. a
PowerBI dashboard entity plus separate PowerBI dataset entities for its
measures/model layer). The existing docs list
`entity_type: dataset, dashboard, chart, corp_user, corp_group, dataProduct, etc.`
without flagging this specific, easy-to-guess-wrong case.

Small, docstring-only change — no code paths touched, so no test/behavior impact.