### PR TITLE
feat: add opt-in get_entities aspect audit context

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Fetch real SQL queries referencing a dataset or column—manual or system-genera
 
 `get_entities`
 
-Fetch detailed metadata for one or more entities by URN; supports batch retrieval for efficient inspection of search results.
+Fetch detailed metadata for one or more entities by URN; supports batch retrieval for efficient inspection of search results. Set `include_system_metadata=true` to add bounded, per-aspect ingestion audit context. These timestamps describe catalog ingestion, not metadata validation; see [`get_entities` aspect audit context](docs/get-entities-audit-context.md).
 
 `list_schema_fields`
 
@@ -224,7 +224,16 @@ Example:
 If the question requires joining or entity navigation (e.g., connecting pets → adoptions):
 
 #### get_entities
-To retrieve entities related to a given URN, such as upstream/downstream tables.
+
+Retrieve detailed metadata for one or more entity URNs. Batch the top candidate URNs from
+search results to compare them efficiently.
+
+For provenance-sensitive inspection, set `include_system_metadata=true` to include a compact
+`aspectMetadata` map with normalized actor URNs, epoch-millisecond times, and selected
+`systemMetadata` fields. The option is off by default for backward compatibility. Ingestion
+timestamps are audit context, **not** proof that metadata was validated or is correct. See
+[`get_entities` aspect audit context](docs/get-entities-audit-context.md) for the response shape,
+limits, and fail-closed behavior.
 
 #### get_lineage_paths_between
 To calculate exact lineage paths between datasets if needed (e.g., between `pet_profiles` and `adoptions`).

--- a/docs/get-entities-audit-context.md
+++ b/docs/get-entities-audit-context.md
@@ -45,8 +45,8 @@ additional request. When enabled, the entity response includes an `aspectMetadat
 
 - `actor` is normalized to a non-empty URN string, whether the server returned a string or an
   object containing `urn`.
-- `time`, `timestamp`, `lastObserved`, and `schemaVersion` are normalized to non-negative
-  integers. Time values are Unix epoch milliseconds.
+- `time`, `timestamp`, `lastObserved`, `schemaVersion`, and system-metadata `version` are
+  normalized to non-negative integers. Time values are Unix epoch milliseconds.
 - The response includes aspect envelope `type`, `version`, `timestamp`, and `created`, plus the
   bounded `systemMetadata` fields useful for ingestion provenance: run IDs, pipeline name,
   registry name/version, aspect version/schema version, observation time, and aspect

--- a/docs/get-entities-audit-context.md
+++ b/docs/get-entities-audit-context.md
@@ -1,0 +1,76 @@
+# `get_entities` aspect audit context
+
+`get_entities` can optionally return bounded, per-aspect ingestion metadata:
+
+```text
+get_entities(
+  urns="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+  include_system_metadata=true,
+)
+```
+
+The default is `false`, so existing callers receive the same response shape and make no
+additional request. When enabled, the entity response includes an `aspectMetadata` map:
+
+```json
+{
+  "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+  "aspectMetadata": {
+    "datasetProperties": {
+      "type": "VERSIONED",
+      "version": 0,
+      "created": {
+        "actor": "urn:li:corpuser:_ingestion",
+        "time": 1761189498008
+      },
+      "systemMetadata": {
+        "lastObserved": 1761189498008,
+        "runId": "snowflake-2026-07-31",
+        "pipelineName": "snowflake-prod",
+        "aspectCreated": {
+          "actor": "urn:li:corpuser:_ingestion",
+          "time": 1761189498008
+        },
+        "aspectModified": {
+          "actor": "urn:li:corpuser:_ingestion",
+          "time": 1761189498008
+        }
+      }
+    }
+  }
+}
+```
+
+## Semantics and limits
+
+- `actor` is normalized to a non-empty URN string, whether the server returned a string or an
+  object containing `urn`.
+- `time`, `timestamp`, `lastObserved`, and `schemaVersion` are normalized to non-negative
+  integers. Time values are Unix epoch milliseconds.
+- The response includes aspect envelope `type`, `version`, `timestamp`, and `created`, plus the
+  bounded `systemMetadata` fields useful for ingestion provenance: run IDs, pipeline name,
+  registry name/version, aspect version/schema version, observation time, and aspect
+  created/modified audit stamps.
+- Raw aspect values are not duplicated. Arbitrary `systemMetadata.properties` are intentionally
+  omitted because they are connector-specific and unbounded.
+- The aspect names are sorted for deterministic responses.
+
+## Ingestion time is not validation time
+
+These timestamps describe when DataHub observed, ingested, created, or modified catalog
+metadata. They do **not** prove when the underlying source data was produced, when a claim was
+independently checked, or whether the metadata is accurate. Actor and pipeline identifiers are
+audit context, not validation verdicts. Consumers must use separate quality checks, assertions,
+or source-specific evidence before treating metadata as validated.
+
+## Failure behavior
+
+The opt-in path fails closed. If the aspect response is malformed, names a different URN, has
+invalid actor/time fields, or contains no aspects, `get_entities` returns an error using its
+existing single-versus-batch behavior:
+
+- A single-URN call raises the error.
+- A batch call records an error object for that URN and continues with the remaining entities.
+
+It never silently drops requested audit context and returns the entity as if provenance were
+available.

--- a/src/mcp_server_datahub/tools/entities.py
+++ b/src/mcp_server_datahub/tools/entities.py
@@ -1,7 +1,7 @@
 """Entity retrieval tools for DataHub MCP server."""
 
 import json
-from typing import Callable, Iterator, List, Optional
+from typing import Any, Callable, Iterator, List, Optional
 
 from datahub.errors import ItemNotFoundError
 from json_repair import repair_json
@@ -17,8 +17,184 @@ query_entity_gql = (graphql_helpers.GQL_DIR / "query_entity.gql").read_text()
 related_documents_gql = (graphql_helpers.GQL_DIR / "related_documents.gql").read_text()
 
 
+def _normalize_non_negative_int(value: Any, *, path: str) -> int:
+    """Normalize a JSON integer while rejecting ambiguous or invalid values."""
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid {path}: expected a non-negative integer")
+
+    if isinstance(value, int):
+        normalized = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped.isdigit():
+            raise ValueError(f"Invalid {path}: expected a non-negative integer")
+        normalized = int(stripped)
+    else:
+        raise ValueError(f"Invalid {path}: expected a non-negative integer")
+
+    if normalized < 0:
+        raise ValueError(f"Invalid {path}: expected a non-negative integer")
+    return normalized
+
+
+def _normalize_actor(value: Any, *, path: str) -> str:
+    """Normalize an audit actor to a non-empty URN string."""
+    actor = value
+    if isinstance(value, dict):
+        actor = value.get("urn")
+
+    if not isinstance(actor, str) or not actor.strip():
+        raise ValueError(
+            f"Invalid {path}: expected a non-empty actor URN string or object"
+        )
+    return actor.strip()
+
+
+def _normalize_audit_stamp(value: Any, *, path: str) -> dict:
+    """Normalize a DataHub AuditStamp to stable actor/time scalar fields."""
+    if not isinstance(value, dict):
+        raise ValueError(f"Invalid {path}: expected an audit stamp object")
+    if "actor" not in value or "time" not in value:
+        raise ValueError(f"Invalid {path}: audit stamp requires actor and time")
+
+    normalized = {
+        "actor": _normalize_actor(value["actor"], path=f"{path}.actor"),
+        "time": _normalize_non_negative_int(value["time"], path=f"{path}.time"),
+    }
+
+    if value.get("impersonator") is not None:
+        normalized["impersonator"] = _normalize_actor(
+            value["impersonator"], path=f"{path}.impersonator"
+        )
+
+    if value.get("message") is not None:
+        message = value["message"]
+        if not isinstance(message, str):
+            raise ValueError(f"Invalid {path}.message: expected a string")
+        if message:
+            normalized["message"] = message
+
+    return normalized
+
+
+def _normalize_system_metadata(value: Any, *, path: str) -> dict:
+    """Select and normalize bounded provenance fields from SystemMetadata."""
+    if not isinstance(value, dict):
+        raise ValueError(f"Invalid {path}: expected a systemMetadata object")
+
+    normalized: dict[str, Any] = {}
+
+    for field_name in (
+        "runId",
+        "lastRunId",
+        "pipelineName",
+        "registryName",
+        "registryVersion",
+        "version",
+    ):
+        field_value = value.get(field_name)
+        if field_value is None:
+            continue
+        if not isinstance(field_value, str):
+            raise ValueError(f"Invalid {path}.{field_name}: expected a string")
+        normalized[field_name] = field_value
+
+    for field_name in ("lastObserved", "schemaVersion"):
+        field_value = value.get(field_name)
+        if field_value is not None:
+            normalized[field_name] = _normalize_non_negative_int(
+                field_value, path=f"{path}.{field_name}"
+            )
+
+    for field_name in ("aspectCreated", "aspectModified"):
+        field_value = value.get(field_name)
+        if field_value is not None:
+            normalized[field_name] = _normalize_audit_stamp(
+                field_value, path=f"{path}.{field_name}"
+            )
+
+    # Deliberately omit SystemMetadata.properties. It is an arbitrary map and can
+    # be large or connector-specific; this opt-in response is an audit summary,
+    # not a second copy of the raw aspect envelope.
+    return normalized
+
+
+def _normalize_aspect_metadata(raw_response: Any, *, expected_urn: str) -> dict:
+    """Build a compact, fail-closed aspect audit map from entitiesV2."""
+    if not isinstance(raw_response, dict):
+        raise ValueError("Invalid aspect metadata response: expected an object")
+
+    response_urn = raw_response.get("urn")
+    if response_urn != expected_urn:
+        raise ValueError(
+            "Invalid aspect metadata response: "
+            f"expected URN {expected_urn}, received {response_urn!r}"
+        )
+
+    aspects = raw_response.get("aspects")
+    if not isinstance(aspects, dict) or not aspects:
+        raise ValueError(
+            f"Invalid aspect metadata response for {expected_urn}: "
+            "expected a non-empty aspects map"
+        )
+
+    normalized_aspects: dict[str, dict] = {}
+    for aspect_name in sorted(aspects):
+        if not isinstance(aspect_name, str) or not aspect_name:
+            raise ValueError(
+                f"Invalid aspect metadata response for {expected_urn}: "
+                "aspect names must be non-empty strings"
+            )
+
+        aspect_path = f"aspectMetadata.{aspect_name}"
+        envelope = aspects[aspect_name]
+        if not isinstance(envelope, dict):
+            raise ValueError(f"Invalid {aspect_path}: expected an aspect envelope")
+
+        envelope_name = envelope.get("name")
+        if envelope_name is not None and envelope_name != aspect_name:
+            raise ValueError(
+                f"Invalid {aspect_path}.name: expected {aspect_name}, "
+                f"received {envelope_name!r}"
+            )
+
+        normalized_envelope: dict[str, Any] = {}
+
+        aspect_type = envelope.get("type")
+        if aspect_type is not None:
+            if not isinstance(aspect_type, str) or not aspect_type:
+                raise ValueError(f"Invalid {aspect_path}.type: expected a string")
+            normalized_envelope["type"] = aspect_type
+
+        for field_name in ("version", "timestamp"):
+            field_value = envelope.get(field_name)
+            if field_value is not None:
+                normalized_envelope[field_name] = _normalize_non_negative_int(
+                    field_value, path=f"{aspect_path}.{field_name}"
+                )
+
+        if envelope.get("created") is not None:
+            normalized_envelope["created"] = _normalize_audit_stamp(
+                envelope["created"], path=f"{aspect_path}.created"
+            )
+
+        if envelope.get("systemMetadata") is not None:
+            system_metadata = _normalize_system_metadata(
+                envelope["systemMetadata"],
+                path=f"{aspect_path}.systemMetadata",
+            )
+            if system_metadata:
+                normalized_envelope["systemMetadata"] = system_metadata
+
+        normalized_aspects[aspect_name] = normalized_envelope
+
+    return normalized_aspects
+
+
 @read_only
-def get_entities(urns: List[str] | str) -> List[dict] | dict:
+def get_entities(
+    urns: List[str] | str, include_system_metadata: bool = False
+) -> List[dict] | dict:
     """Get detailed information about one or more entities by their DataHub URNs.
 
     IMPORTANT: Pass an array of URNs to retrieve multiple entities in a single call - this is much
@@ -28,8 +204,18 @@ def get_entities(urns: List[str] | str) -> List[dict] | dict:
     Accepts an array of URNs or a single URN. Supports all entity types including datasets,
     assertions, incidents, dashboards, charts, users, groups, and more. The response fields vary
     based on the entity type.
+
+    Set include_system_metadata=true to add an aspectMetadata map keyed by aspect name. Each
+    entry contains available aspect envelope audit data and selected systemMetadata fields, with
+    actor values normalized to URN strings and time values normalized to epoch-millisecond
+    integers. This is ingestion/catalog processing context, not evidence that the metadata was
+    validated or is semantically correct. The opt-in audit read fails closed: malformed or
+    mismatched metadata returns an error instead of silently omitting the requested context.
     """
     client = graphql_helpers.get_datahub_client()
+
+    if not isinstance(include_system_metadata, bool):
+        raise ValueError("include_system_metadata must be a boolean")
 
     # Handle JSON-stringified arrays (same issue as filters in search tool)
     # Some MCP clients/LLMs pass arrays as JSON strings instead of proper lists
@@ -124,7 +310,16 @@ def get_entities(urns: List[str] | str) -> List[dict] | dict:
             graphql_helpers.inject_urls_for_urns(client._graph, result, [""])
             graphql_helpers.truncate_descriptions(result)
 
-            results.append(graphql_helpers.clean_get_entities_response(result))
+            cleaned_result = graphql_helpers.clean_get_entities_response(result)
+
+            if include_system_metadata:
+                raw_aspect_metadata = client._graph.get_entity_raw(urn)
+                cleaned_result["aspectMetadata"] = _normalize_aspect_metadata(
+                    raw_aspect_metadata,
+                    expected_urn=urn,
+                )
+
+            results.append(cleaned_result)
 
         except Exception as e:
             logger.warning(f"Error fetching entity {urn}: {e}")

--- a/src/mcp_server_datahub/tools/entities.py
+++ b/src/mcp_server_datahub/tools/entities.py
@@ -90,7 +90,6 @@ def _normalize_system_metadata(value: Any, *, path: str) -> dict:
         "pipelineName",
         "registryName",
         "registryVersion",
-        "version",
     ):
         field_value = value.get(field_name)
         if field_value is None:
@@ -99,7 +98,7 @@ def _normalize_system_metadata(value: Any, *, path: str) -> dict:
             raise ValueError(f"Invalid {path}.{field_name}: expected a string")
         normalized[field_name] = field_value
 
-    for field_name in ("lastObserved", "schemaVersion"):
+    for field_name in ("lastObserved", "schemaVersion", "version"):
         field_value = value.get(field_name)
         if field_value is not None:
             normalized[field_name] = _normalize_non_negative_int(

--- a/tests/test_mcp/test_get_entities_audit_context.py
+++ b/tests/test_mcp/test_get_entities_audit_context.py
@@ -140,7 +140,7 @@ async def test_opt_in_adds_normalized_bounded_aspect_metadata(
         "pipelineName": "snowflake-prod",
         "registryName": "datahub",
         "registryVersion": "1.0",
-        "version": "3",
+        "version": 3,
         "lastObserved": 1761189498008,
         "schemaVersion": 1,
         "aspectCreated": {

--- a/tests/test_mcp/test_get_entities_audit_context.py
+++ b/tests/test_mcp/test_get_entities_audit_context.py
@@ -1,0 +1,248 @@
+"""Focused tests for opt-in aspect audit context in get_entities."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_integrations.mcp.mcp_server import async_background
+
+pytestmark = pytest.mark.anyio
+
+URN = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)"
+
+
+@pytest.fixture
+def mock_client():
+    client = Mock()
+    client._graph = Mock()
+    client._graph.exists.return_value = True
+    return client
+
+
+@pytest.fixture
+def entity_response():
+    return {
+        "urn": URN,
+        "type": "DATASET",
+        "name": "table",
+    }
+
+
+def _aspect_response(*, urn: str = URN, last_observed: object = "1761189498008"):
+    return {
+        "urn": urn,
+        "aspects": {
+            "datasetProperties": {
+                "name": "datasetProperties",
+                "type": "VERSIONED",
+                "version": "0",
+                "value": {"description": "not copied into aspectMetadata"},
+                "created": {
+                    "actor": {"urn": " urn:li:corpuser:_ingestion "},
+                    "time": "1761189498008",
+                },
+                "systemMetadata": {
+                    "lastObserved": last_observed,
+                    "runId": "snowflake-run",
+                    "lastRunId": "snowflake-run-latest",
+                    "pipelineName": "snowflake-prod",
+                    "registryName": "datahub",
+                    "registryVersion": "1.0",
+                    "version": "3",
+                    "schemaVersion": "1",
+                    "properties": {
+                        "connectorSpecific": "intentionally omitted",
+                    },
+                    "aspectCreated": {
+                        "actor": "urn:li:corpuser:creator",
+                        "time": 1761189400000,
+                    },
+                    "aspectModified": {
+                        "actor": {"urn": "urn:li:corpuser:modifier"},
+                        "time": "1761189498008",
+                        "impersonator": {"urn": "urn:li:corpuser:ingestion-service"},
+                        "message": "metadata ingested",
+                    },
+                },
+            },
+            "datasetKey": {
+                "name": "datasetKey",
+                "type": "VERSIONED",
+                "version": 0,
+                "created": {
+                    "actor": "urn:li:corpuser:datahub",
+                    "time": 1761189300000,
+                },
+            },
+        },
+    }
+
+
+async def test_default_response_is_unchanged_and_makes_no_audit_request(
+    mock_client, entity_response
+):
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+        ) as mock_graphql,
+    ):
+        mock_graphql.side_effect = [
+            {"entity": entity_response},
+            {"entity": {}},
+        ]
+
+        from datahub_integrations.mcp.mcp_server import get_entities
+
+        result = await async_background(get_entities)(URN)
+
+    assert result == entity_response
+    assert "aspectMetadata" not in result
+    mock_client._graph.get_entity_raw.assert_not_called()
+
+
+async def test_opt_in_adds_normalized_bounded_aspect_metadata(
+    mock_client, entity_response
+):
+    mock_client._graph.get_entity_raw.return_value = _aspect_response()
+
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+        ) as mock_graphql,
+    ):
+        mock_graphql.side_effect = [
+            {"entity": entity_response},
+            {"entity": {}},
+        ]
+
+        from datahub_integrations.mcp.mcp_server import get_entities
+
+        result = await async_background(get_entities)(URN, include_system_metadata=True)
+
+    assert list(result["aspectMetadata"]) == ["datasetKey", "datasetProperties"]
+    dataset_properties = result["aspectMetadata"]["datasetProperties"]
+    assert dataset_properties["version"] == 0
+    assert dataset_properties["created"] == {
+        "actor": "urn:li:corpuser:_ingestion",
+        "time": 1761189498008,
+    }
+    assert dataset_properties["systemMetadata"] == {
+        "runId": "snowflake-run",
+        "lastRunId": "snowflake-run-latest",
+        "pipelineName": "snowflake-prod",
+        "registryName": "datahub",
+        "registryVersion": "1.0",
+        "version": "3",
+        "lastObserved": 1761189498008,
+        "schemaVersion": 1,
+        "aspectCreated": {
+            "actor": "urn:li:corpuser:creator",
+            "time": 1761189400000,
+        },
+        "aspectModified": {
+            "actor": "urn:li:corpuser:modifier",
+            "time": 1761189498008,
+            "impersonator": "urn:li:corpuser:ingestion-service",
+            "message": "metadata ingested",
+        },
+    }
+    assert "value" not in dataset_properties
+    assert "properties" not in dataset_properties["systemMetadata"]
+    mock_client._graph.get_entity_raw.assert_called_once_with(URN)
+
+
+@pytest.mark.parametrize(
+    ("aspect_response", "message"),
+    [
+        (_aspect_response(urn="urn:li:dataset:other"), "expected URN"),
+        (_aspect_response(last_observed="not-a-time"), "lastObserved"),
+        ({"urn": URN, "aspects": {}}, "non-empty aspects map"),
+    ],
+)
+async def test_opt_in_fails_closed_for_invalid_audit_payload(
+    mock_client, entity_response, aspect_response, message
+):
+    mock_client._graph.get_entity_raw.return_value = aspect_response
+
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+        ) as mock_graphql,
+    ):
+        mock_graphql.side_effect = [
+            {"entity": entity_response},
+            {"entity": {}},
+        ]
+
+        from datahub_integrations.mcp.mcp_server import get_entities
+
+        with pytest.raises(ValueError, match=message):
+            await async_background(get_entities)(URN, include_system_metadata=True)
+
+
+async def test_batch_preserves_existing_per_entity_error_behavior(
+    mock_client, entity_response
+):
+    other_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.other,PROD)"
+    mock_client._graph.get_entity_raw.side_effect = [
+        _aspect_response(),
+        _aspect_response(urn=URN),
+    ]
+
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+        ) as mock_graphql,
+    ):
+        mock_graphql.side_effect = [
+            {"entity": entity_response},
+            {"entity": {}},
+            {"entity": {**entity_response, "urn": other_urn, "name": "other"}},
+            {"entity": {}},
+        ]
+
+        from datahub_integrations.mcp.mcp_server import get_entities
+
+        result = await async_background(get_entities)(
+            [URN, other_urn], include_system_metadata=True
+        )
+
+    assert result[0]["urn"] == URN
+    assert "aspectMetadata" in result[0]
+    assert result[1]["urn"] == other_urn
+    assert "error" in result[1]
+    assert "expected URN" in result[1]["error"]
+
+
+async def test_include_system_metadata_rejects_non_boolean(
+    mock_client, entity_response
+):
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_client,
+    ):
+        from datahub_integrations.mcp.mcp_server import get_entities
+
+        with pytest.raises(
+            ValueError, match="include_system_metadata must be a boolean"
+        ):
+            await async_background(get_entities)(
+                URN,
+                include_system_metadata="true",  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
## Summary

Add opt-in, read-only aspect audit context to `get_entities`.

Closes #159.

## Contract

- `include_system_metadata=false` preserves the existing response path and makes no raw-aspect request.
- `include_system_metadata=true` adds a deterministic `aspectMetadata` map.
- Actor values are normalized to URN strings.
- Time/version fields are normalized to non-negative integers.
- Raw aspect `value` and arbitrary `systemMetadata.properties` are omitted.
- Malformed audit payloads fail closed using existing single-URN versus batch error behavior.
- Documentation explicitly states that DataHub ingestion/observation timestamps are not metadata validation timestamps.

## Included audit fields

- aspect envelope: `type`, `version`, `timestamp`, `created`
- system metadata: run IDs, pipeline, registry name/version, aspect/schema versions, `lastObserved`, `aspectCreated`, and `aspectModified`

## Validation

- `uv run pytest -q tests/test_mcp/test_get_entities.py tests/test_mcp/test_get_entities_audit_context.py`
  - 23 passed
- `uv run ruff check src/mcp_server_datahub/tools/entities.py tests/test_mcp/test_get_entities_audit_context.py`
  - pass
- `uv run ruff format --check ...`
  - pass

No mutation tool, raw aspect value, credential field, dependency, or tool registration is added.
