### PR TITLE
fix(telemetry): send pings off the request path

### DIFF
--- a/src/mcp_server_datahub/_telemetry.py
+++ b/src/mcp_server_datahub/_telemetry.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -15,6 +16,40 @@ logger = logging.getLogger(__name__)
 telemetry.telemetry_instance.add_global_property(
     "mcp_server_datahub_version", __version__
 )
+
+# Strong references to in-flight telemetry tasks. asyncio only holds a weak
+# reference to a running task, so without this the task can be garbage
+# collected before it completes.
+_background_pings: set["asyncio.Task[None]"] = set()
+
+
+def _on_ping_done(task: "asyncio.Task[None]") -> None:
+    _background_pings.discard(task)
+    if not task.cancelled() and task.exception() is not None:
+        logger.debug("Telemetry ping failed", exc_info=task.exception())
+
+
+def _ping_in_background(event_name: str, properties: dict[str, Any]) -> None:
+    """Send a telemetry ping without making the caller wait for it.
+
+    `telemetry_instance.ping()` performs a blocking HTTP request. Calling it
+    inline from the request path means every tool call waits for the telemetry
+    endpoint to answer, and blocks the event loop while it waits — so a slow or
+    unreachable endpoint delays each call by however long that request takes.
+
+    Telemetry is best-effort, so hand it to a worker thread and do not await it.
+    """
+    try:
+        task = asyncio.create_task(
+            asyncio.to_thread(telemetry.telemetry_instance.ping, event_name, properties)
+        )
+    except RuntimeError:
+        # No running event loop — there is nothing to block, so send inline.
+        telemetry.telemetry_instance.ping(event_name, properties)
+        return
+
+    _background_pings.add(task)
+    task.add_done_callback(_on_ping_done)
 
 
 def _get_client_info(context: MiddlewareContext[Any]) -> dict[str, str]:
@@ -82,6 +117,4 @@ class TelemetryMiddleware(Middleware):
                 raise
             finally:
                 telemetry_data["duration_seconds"] = timer.elapsed_seconds()
-                telemetry.telemetry_instance.ping(
-                    "mcp-server-tool-call", telemetry_data
-                )
+                _ping_in_background("mcp-server-tool-call", telemetry_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,12 @@ if using_oss:
     mcp_module._token_estimator = _token_estimator  # type: ignore[attr-defined]
     sys.modules["datahub_integrations.mcp._token_estimator"] = _token_estimator
 
+    # Import and expose _telemetry
+    from mcp_server_datahub import _telemetry
+
+    mcp_module._telemetry = _telemetry  # type: ignore[attr-defined]
+    sys.modules["datahub_integrations.mcp._telemetry"] = _telemetry
+
     # Create datahub_integrations.mcp.tools submodule
     tools_module = types.ModuleType("datahub_integrations.mcp.tools")
     sys.modules["datahub_integrations.mcp.tools"] = tools_module

--- a/tests/test_mcp/test_telemetry_middleware.py
+++ b/tests/test_mcp/test_telemetry_middleware.py
@@ -1,0 +1,95 @@
+"""
+Tests for TelemetryMiddleware.
+
+Telemetry is best-effort and must never sit on the request path. `ping()` makes a
+blocking HTTP call, so sending it inline made every tool call wait for the telemetry
+endpoint to answer.
+
+These tests deliberately reference only the public middleware surface, so they fail on
+the blocking behaviour itself rather than on a missing internal symbol.
+"""
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import mcp.types as mt
+import pytest
+from datahub.telemetry import telemetry
+
+from datahub_integrations.mcp._telemetry import TelemetryMiddleware
+
+# How long the stubbed telemetry endpoint "hangs" for.
+PING_SECONDS = 2.0
+
+
+def _make_context() -> MagicMock:
+    context = MagicMock()
+    context.message.name = "search"
+    # No FastMCP request context; _get_client_info should degrade quietly.
+    context.fastmcp_context = None
+    return context
+
+
+def _tool_result() -> SimpleNamespace:
+    return SimpleNamespace(content=[mt.TextContent(type="text", text="ok")])
+
+
+@pytest.mark.anyio
+async def test_slow_telemetry_does_not_delay_tool_call(monkeypatch) -> None:
+    """A hanging telemetry endpoint must not add latency to the tool result."""
+    pinged = threading.Event()
+
+    def slow_ping(*args, **kwargs) -> None:
+        time.sleep(PING_SECONDS)
+        pinged.set()
+
+    monkeypatch.setattr(telemetry.telemetry_instance, "ping", slow_ping)
+
+    expected = _tool_result()
+    call_next = AsyncMock(return_value=expected)
+
+    start = time.monotonic()
+    result = await TelemetryMiddleware().on_call_tool(_make_context(), call_next)
+    elapsed = time.monotonic() - start
+
+    assert result is expected
+    assert elapsed < PING_SECONDS / 2, (
+        f"tool call blocked {elapsed:.2f}s waiting on telemetry"
+    )
+
+    # The ping is still delivered — just off the request path.
+    assert await asyncio.to_thread(pinged.wait, PING_SECONDS * 3)
+
+
+@pytest.mark.anyio
+async def test_telemetry_failure_does_not_break_tool_call(monkeypatch) -> None:
+    """A telemetry endpoint that raises must not surface to the caller."""
+    attempted = threading.Event()
+
+    def failing_ping(*args, **kwargs) -> None:
+        attempted.set()
+        raise RuntimeError("telemetry endpoint unreachable")
+
+    monkeypatch.setattr(telemetry.telemetry_instance, "ping", failing_ping)
+
+    expected = _tool_result()
+    call_next = AsyncMock(return_value=expected)
+
+    result = await TelemetryMiddleware().on_call_tool(_make_context(), call_next)
+
+    assert result is expected
+    assert await asyncio.to_thread(attempted.wait, PING_SECONDS)
+
+
+@pytest.mark.anyio
+async def test_tool_errors_still_propagate(monkeypatch) -> None:
+    """Errors raised by the tool itself must still reach the caller."""
+    monkeypatch.setattr(telemetry.telemetry_instance, "ping", lambda *a, **k: None)
+
+    call_next = AsyncMock(side_effect=ValueError("boom"))
+
+    with pytest.raises(ValueError, match="boom"):
+        await TelemetryMiddleware().on_call_tool(_make_context(), call_next)


### PR DESCRIPTION
Fixes #152.

## Problem

`TelemetryMiddleware.on_call_tool` sends its telemetry ping inline, in the `finally` block:

```python
finally:
    telemetry_data["duration_seconds"] = timer.elapsed_seconds()
    telemetry.telemetry_instance.ping("mcp-server-tool-call", telemetry_data)
```

`ping()` performs a blocking HTTP request, so every tool call waits for the telemetry endpoint before its result is returned. Because it is a synchronous call inside an async middleware, it also blocks the event loop for that duration rather than just the one request.

When the endpoint is slow or unreachable, this adds a fixed delay to **every** tool call. #152 measures ~54s per call, near-constant across `list_schema_fields` (8 fields), `get_lineage` (4 datasets), and `get_lineage_paths_between` — near-identical durations across tools of very different cost is the signature of a fixed timeout, not of query work. The reporter's lineage traversal timed out after 50 minutes; with `DATAHUB_TELEMETRY_ENABLED=false` the same traversal finished in 70 seconds.

This also violates an invariant the repo already asserts in `tests/test_mcp/test_async_setup.py::test_all_tools_are_async` — *"If any tools are sync, the tool execution will block the main event loop."* The tools comply; the middleware wrapping them did not.

## Fix

Hand the ping to a worker thread and don't await it. Telemetry is best-effort, so it should never sit on the request path.

A module-level set holds strong references to in-flight tasks — `asyncio` keeps only a weak reference, so without this a task can be garbage collected before it runs. Failures are logged at `debug` and never surface to the caller. If there is no running event loop the ping is sent inline, since there is nothing to block.

No change to what is collected or when — only to who waits for it.

## Verification

`tests/test_mcp/test_telemetry_middleware.py` stubs a telemetry endpoint that hangs for 2s and asserts the tool result returns in well under that. It references only the public middleware surface, so it fails on the blocking behaviour itself rather than on a missing symbol:

```
# without this patch
AssertionError: tool call blocked 2.00s waiting on telemetry
assert 2.001845374936238 < (2.0 / 2)
2 failed, 1 passed

# with this patch
3 passed
```

Two further cases cover a telemetry endpoint that raises (must not surface to the caller) and errors raised by the tool itself (must still propagate).

Full suite: **504 passed**. `ruff format`, `ruff check`, and `mypy` all clean.

`tests/conftest.py` gains a `_telemetry` entry in the `datahub_integrations` compatibility shim so the new test resolves in both repo layouts, matching the existing pattern.