### PR TITLE
docs: correct the claim that tests need a live DataHub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,17 @@ A quick summary is below:
 
 - `make setup` - Set up development environment (requires uv)
 - `make lint` - Run ruff formatting, linting and type checking
-- `make test` - Run pytest tests (requires live DataHub instance)
+- `make test` - Run pytest tests (most run offline; only the integration tests need a live DataHub instance)
 - `make clean` - Clean up build artifacts
 
 ## Testing
 
 - Run all tests: `make test`
-- Single test file: `uv run pytest tests/test_mcp_server.py`
-- Tests require a live DataHub instance with proper authentication
+- Single test file: `uv run pytest tests/test_mcp/test_search_documents.py`
+- Most tests run offline against mocked GraphQL responses — no DataHub instance needed.
+- The integration tests in `tests/test_mcp_integration.py` require a live DataHub instance
+  with authentication (`DATAHUB_GMS_URL` / `DATAHUB_GMS_TOKEN`, or `~/.datahubenv`). They
+  skip automatically when no credentials are available.
 
 ## Development Setup
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -56,11 +56,13 @@ make lint
 
 ### Run tests
 
-The test suite is currently very simplistic, and requires a live DataHub instance.
-
 ```bash
 make test
 ```
+
+Most of the suite runs offline against mocked GraphQL responses and needs no DataHub
+instance. The integration tests in `tests/test_mcp_integration.py` do require a live
+DataHub and credentials — they skip automatically when none are configured.
 
 ## Publishing
 


### PR DESCRIPTION
### What

`DEVELOPING.md` and `CLAUDE.md` both say the test suite requires a live DataHub instance. It mostly doesn't.

**506 tests pass with no DataHub reachable at all**, against mocked GraphQL responses:

```
$ DATAHUB_GMS_URL=http://127.0.0.1:9 uv run pytest tests/
506 passed, 39 errors
```

The 39 are all `tests/test_mcp_integration.py`, which genuinely does need a live instance — and which already skips itself cleanly when no credentials are configured:

```
$ uv run pytest tests/
506 passed, 39 skipped
SKIPPED [1] tests/test_mcp_integration.py:100: No credentials available, skipping tests
```

### Why it matters

The current wording tells a new contributor they have to stand up DataHub before they can run anything. For a one-file change that's a real barrier, and it isn't true — the unit tests are fast (~6s) and need nothing.

### Also fixed

`CLAUDE.md` gives `uv run pytest tests/test_mcp_server.py` as the single-test-file example. That path doesn't exist; pointed it at a real one.

Docs only, no behaviour change.
