### PR TITLE
Decide newer-GMS fields by version, not by whether it is Cloud

### DIFF
--- a/src/mcp_server_datahub/graphql_helpers.py
+++ b/src/mcp_server_datahub/graphql_helpers.py
@@ -365,27 +365,71 @@ def _disable_cloud_fields(query: str) -> str:
 _newer_gms_fields_support_cache: dict[int, bool] = {}
 
 
+# Minimum OSS/Core GMS version that serves the #[NEWER_GMS] fields.
+#
+# Documents (Document.info.contents, subType, relatedAssets, ...) landed in OSS
+# 1.5.0, which is also where the rest of the #[NEWER_GMS] block became valid.
+# Verified against a 1.5.0.6 quickstart: the full entity_details.gql query with
+# every #[NEWER_GMS] field enabled validates and resolves without error.
+NEWER_GMS_MIN_OSS_VERSION = (1, 5, 0, 0)
+
+
 def _is_datahub_cloud(graph: DataHubGraph) -> bool:
     """Check if the graph instance is DataHub Cloud.
 
-    Cloud instances typically have newer GMS versions with additional fields.
     This heuristic uses the presence of frontend_base_url to detect Cloud instances.
     """
-    # Allow disabling newer GMS field detection via environment variable
-    # This is useful when the GMS version doesn't support all newer fields
+    # Retained here, unchanged, so that setting the flag still disables #[CLOUD]
+    # fields exactly as it did before -- that side effect is relied on in the
+    # field-only override path and is not what this change is about.
+    if get_boolean_env_variable("DISABLE_NEWER_GMS_FIELD_DETECTION", default=False):
+        return False
+
+    try:
+        # Only DataHub Cloud has a frontend base url.
+        _ = graph.frontend_base_url
+    except ValueError:
+        return False
+    return True
+
+
+def _supports_newer_gms_fields(graph: DataHubGraph, is_cloud: bool) -> bool:
+    """Check whether this server serves the #[NEWER_GMS] fields.
+
+    Cloud always does. A self-hosted server does too, once it is new enough --
+    which is the case this previously got wrong. The initial guess used to be
+    ``is_cloud`` alone, on the reasoning that Cloud "typically" runs a newer GMS.
+    The contrapositive does not hold: an OSS server on 1.5+ serves every one of
+    these fields, and gating them on deployment type stripped them anyway. The
+    visible symptom was ``get_entities`` on a Document URN returning ``{"urn":
+    ...}`` and nothing else on OSS -- no title, no contents -- because the whole
+    ``... on Document`` block is #[NEWER_GMS]-tagged. The same query against the
+    same server with the fields enabled returns the document in full.
+
+    Guessing wrong in either direction is recoverable: ``execute_graphql``
+    retries once with the fields disabled on a validation error and caches the
+    answer per graph, so an over-optimistic guess costs one round trip on the
+    first query and nothing after it.
+    """
+    # Allow disabling newer GMS field detection via environment variable.
+    # This is useful when the GMS version doesn't support all newer fields.
     if get_boolean_env_variable("DISABLE_NEWER_GMS_FIELD_DETECTION", default=False):
         logger.debug(
             "Newer GMS field detection disabled via DISABLE_NEWER_GMS_FIELD_DETECTION"
         )
         return False
 
+    if is_cloud:
+        return True
+
     try:
-        # Only DataHub Cloud has a frontend base url.
-        # Cloud instances typically run newer GMS versions with additional fields.
-        _ = graph.frontend_base_url
-    except ValueError:
+        return graph.server_config.is_version_at_least(*NEWER_GMS_MIN_OSS_VERSION)
+    except Exception as e:
+        # An unreachable or unparseable /config should not decide field
+        # selection. Fall back to the old conservative behaviour and let the
+        # retry path correct it if the fields are in fact available.
+        logger.debug(f"Could not determine GMS version, assuming older GMS: {e}")
         return False
-    return True
 
 
 def _is_field_validation_error(error_msg: str) -> bool:
@@ -431,15 +475,16 @@ def execute_graphql(
         else:
             query = _disable_newer_gms_fields(query)
     else:
-        # First attempt: try with newer GMS fields if it's detected as cloud
-        # (Cloud instances typically run newer GMS versions)
-        if is_cloud:
+        # First attempt: enable newer GMS fields if the server actually serves
+        # them -- Cloud, or a self-hosted GMS new enough to have them.
+        supports_newer_fields = _supports_newer_gms_fields(graph, is_cloud)
+        if supports_newer_fields:
             query = _enable_newer_gms_fields(query)
             newer_gms_enabled_for_this_query = True
         else:
             query = _disable_newer_gms_fields(query)
         # Cache the initial detection result
-        _newer_gms_fields_support_cache[graph_id] = is_cloud
+        _newer_gms_fields_support_cache[graph_id] = supports_newer_fields
 
     logger.debug(
         f"Executing GraphQL {operation_name or 'query'}: "

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -44,6 +44,7 @@ from .graphql_helpers import (  # noqa: F401 (re-exported for backward compat)
     _enable_newer_gms_fields,
     _is_datahub_cloud,
     _select_results_within_budget,
+    _supports_newer_gms_fields,
     _sort_fields_by_priority,
     clean_get_entities_response,
     clean_gql_response,

--- a/tests/test_mcp/test_newer_gms_detection.py
+++ b/tests/test_mcp/test_newer_gms_detection.py
@@ -1,0 +1,67 @@
+"""Tests for deciding whether a server serves the #[NEWER_GMS] fields.
+
+The regression these cover: the decision used to be "is this DataHub Cloud?",
+which stripped every #[NEWER_GMS] field from queries sent to a self-hosted
+server no matter how new it was. Because the entire ``... on Document`` block in
+``entity_details.gql`` is #[NEWER_GMS]-tagged, ``get_entities`` on a Document URN
+came back as ``{"urn": ...}`` with no title and no contents on OSS -- while the
+same server answered the same query in full when the fields were left in.
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from datahub_integrations.mcp.mcp_server import _supports_newer_gms_fields
+
+
+def _graph(version: tuple[int, int, int, int] | None, *, cloud: bool) -> MagicMock:
+    """A stand-in DataHubGraph reporting a given version and deployment type."""
+    graph = MagicMock()
+    config = MagicMock()
+    config.parsed_version = version
+    config.is_version_at_least.side_effect = lambda *want: (
+        version or (0, 0, 0, 0)
+    ) >= tuple(list(want) + [0] * (4 - len(want)))
+    type(graph).server_config = PropertyMock(return_value=config)
+    return graph
+
+
+def test_oss_on_a_new_enough_server_gets_the_newer_fields():
+    """The reported bug: OSS 1.5.0.6 serves these fields and was denied them."""
+    assert (
+        _supports_newer_gms_fields(_graph((1, 5, 0, 6), cloud=False), is_cloud=False)
+        is True
+    )
+
+
+def test_oss_on_an_older_server_does_not():
+    assert (
+        _supports_newer_gms_fields(_graph((1, 4, 0, 0), cloud=False), is_cloud=False)
+        is False
+    )
+
+
+def test_cloud_is_unchanged_and_does_not_depend_on_the_version_lookup():
+    """Cloud took this path before and must keep taking it, version or no version."""
+    graph = _graph(None, cloud=True)
+    assert _supports_newer_gms_fields(graph, is_cloud=True) is True
+
+
+def test_the_opt_out_still_wins():
+    with patch(
+        "mcp_server_datahub.graphql_helpers.get_boolean_env_variable", return_value=True
+    ):
+        assert (
+            _supports_newer_gms_fields(
+                _graph((1, 5, 0, 6), cloud=False), is_cloud=False
+            )
+            is False
+        )
+
+
+def test_an_unreadable_config_falls_back_instead_of_raising():
+    """A server whose /config cannot be read must not break field selection."""
+    graph = MagicMock()
+    type(graph).server_config = PropertyMock(
+        side_effect=Exception("connection refused")
+    )
+    assert _supports_newer_gms_fields(graph, is_cloud=False) is False


### PR DESCRIPTION
## The bug

`get_entities` on a Document URN returns `{"urn": "..."}` on self-hosted DataHub — no title, no contents, no related assets. An agent can write a document with `save_document` and has no way to read it back. Filed as a capability gap; it is not one.

`entity_details.gql` *does* select the document's title and contents. Every one of those lines is tagged `#[NEWER_GMS]`, and `execute_graphql` enables those fields only when the server looks like DataHub Cloud:

```python
# First attempt: try with newer GMS fields if it's detected as cloud
# (Cloud instances typically run newer GMS versions)
if is_cloud:
    query = _enable_newer_gms_fields(query)
```

"Cloud typically runs a newer GMS" is true. The inference that a self-hosted server therefore does not is not — an OSS server on 1.5+ serves every one of these fields and was having them stripped on the way out.

## Evidence

Against an OSS quickstart at GMS **v1.5.0.6**, sending the whole of `entity_details.gql` both ways:

| `#[NEWER_GMS]` fields | GraphQL result | Fields returned |
| --- | --- | --- |
| stripped (what OSS gets today) | no errors | `urn` — and nothing else |
| left in | no errors | `urn`, `info`, `subType`, `platform`, `ownership`, `tags`, `domain`, `glossaryTerms` — title and **5,102 characters** of content |

No validation errors either way: all 76 `#[NEWER_GMS]` fields in that query resolve on 1.5.0.6.

## The change

Decide on the **version** rather than the deployment type — Cloud as before, self-hosted once it is at least 1.5.0, read from `server_config`, which this codebase already consults for tool-level version gating.

Guessing wrong stays cheap because the recovery path is untouched: `execute_graphql` already retries once with the fields disabled on a validation error and caches the answer per graph. An over-optimistic guess costs one round trip on the first query and nothing afterwards. `DISABLE_NEWER_GMS_FIELD_DETECTION` still forces the old behaviour, including its existing side effect on `#[CLOUD]` fields.

## Tests

Five new, covering the OSS-1.5 case that was the bug, an older OSS server, Cloud, the env opt-out, and a server whose `/config` cannot be read (falls back rather than raising).

Worth noting: `test_combined_tags_scenario` already asserted *"Scenario 2: OSS instance (CLOUD fields hidden, NEWER_GMS shown)"*. This brings the behaviour into line with what the tests said it was.

Full suite after the change: **506 passed**, `ruff` and `mypy` clean.

## Verified end to end

Through the patched code path against that 1.5.0.6 server:

```
server: OSS=True version=(1, 5, 0, 6)
_is_datahub_cloud      -> False
_supports_newer_fields -> True

get_entities fields returned: ['domain', 'glossaryTerms', 'info', 'ownership',
                               'platform', 'settings', 'subType', 'tags', 'urn']
title  : 'Stale runbook: Weekly order revenue pack'
content: 5102 chars
```

Found while building a tool that writes runbooks into DataHub with `save_document` and re-validates them against the catalog later — we could not re-read our own documents, so the body had to live outside the catalog.
