### PR TITLE
feat: add LangChain incident response agent examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .claude/settings.local.json
 .graphqlrc.yml
 
+# macOS
+.DS_Store
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: setup clean format format-check lint lint-check test
 
-PY_FILES = src tests scripts
+# Formatted and linted with ruff.
+PY_FILES = src tests scripts examples
+# Type-checked with mypy. Excludes examples/, whose dependencies (langchain,
+# etc.) are intentionally not part of this project's dev environment.
+MYPY_FILES = src tests scripts
 
 # Setup development environment
 setup:
@@ -15,10 +19,10 @@ format-check:
 # Lint with ruff and mypy
 lint: format
 	uv run ruff check --fix $(PY_FILES)
-	uv run mypy $(PY_FILES)
+	uv run mypy $(MYPY_FILES)
 lint-check: format-check
 	uv run ruff check $(PY_FILES)
-	uv run mypy $(PY_FILES)
+	uv run mypy $(MYPY_FILES)
 
 # Run tests
 test:

--- a/examples/langchain_incident_agent/README.md
+++ b/examples/langchain_incident_agent/README.md
@@ -46,6 +46,15 @@ export DATAHUB_GMS_TOKEN="<your-token>"          # required for DataHub Cloud
 | `DATAHUB_GMS_TOKEN` | For DataHub Cloud | _none_ | Auth token |
 | `DATAHUB_ACTOR_URN` | No | `urn:li:corpuser:datahub` | Actor recorded as having filed the incident |
 
+The agent needs a real dataset URN. Find one in your DataHub UI, or run:
+
+```bash
+datahub search --entity dataset
+```
+
+The tool verifies the dataset exists before filing, so a wrong URN fails with a
+clear error rather than creating an orphaned incident.
+
 ## Usage
 
 Run it from inside this directory (`agent.py` imports `tools.py` as a sibling
@@ -53,10 +62,10 @@ module):
 
 ```bash
 cd examples/langchain_incident_agent
-python agent.py "The dataset urn:li:dataset:(urn:li:dataPlatform:snowflake,showcase.ecommerce.orders,PROD) is stale. Please log an incident."
+python agent.py "The dataset urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD) is stale. Please log an incident."
 ```
 
-With no argument, it runs a built-in sample query.
+With no argument, it prints usage and exits.
 
 The tool needs a **full dataset URN**. If you give it only a table name, it will
 ask you for the URN rather than inventing one. You can find a dataset's URN in

--- a/examples/langchain_incident_agent/README.md
+++ b/examples/langchain_incident_agent/README.md
@@ -1,0 +1,83 @@
+# LangChain Incident Agent
+
+A minimal example of a local LangChain agent that turns a plain-English report
+("the orders pipeline is stale") into an incident filed against a dataset in
+DataHub.
+
+The agent runs entirely locally against [Ollama](https://ollama.com) — no data
+leaves your machine except the incident written to your DataHub instance.
+
+## How it works
+
+- [`tools.py`](tools.py) exposes a single LangChain tool, `create_datahub_incident`,
+  which emits an `incidentInfo` aspect via the DataHub REST emitter.
+- [`agent.py`](agent.py) wires that tool up to a local chat model and lets the
+  model decide the incident type and which dataset it applies to.
+
+## Prerequisites
+
+1. **Ollama**, with the model this example uses pulled locally:
+
+   ```bash
+   ollama pull qwen3:8b
+   ```
+
+   To use a different model, change `MODEL` in [`agent.py`](agent.py). It must be
+   a model that supports tool calling.
+
+2. **A running DataHub instance** you can write to.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+Point the example at your DataHub instance:
+
+```bash
+export DATAHUB_GMS_URL="http://localhost:8080"   # defaults to this if unset
+export DATAHUB_GMS_TOKEN="<your-token>"          # required for DataHub Cloud
+```
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `DATAHUB_GMS_URL` | No | `http://localhost:8080` | DataHub GMS endpoint |
+| `DATAHUB_GMS_TOKEN` | For DataHub Cloud | _none_ | Auth token |
+| `DATAHUB_ACTOR_URN` | No | `urn:li:corpuser:datahub` | Actor recorded as having filed the incident |
+
+## Usage
+
+Run it from inside this directory (`agent.py` imports `tools.py` as a sibling
+module):
+
+```bash
+cd examples/langchain_incident_agent
+python agent.py "The dataset urn:li:dataset:(urn:li:dataPlatform:snowflake,showcase.ecommerce.orders,PROD) is stale. Please log an incident."
+```
+
+With no argument, it runs a built-in sample query.
+
+The tool needs a **full dataset URN**. If you give it only a table name, it will
+ask you for the URN rather than inventing one. You can find a dataset's URN in
+the DataHub UI, or via this repo's MCP `search` tool.
+
+## Incident types
+
+The model picks one of these based on the symptom described:
+
+| Type | Use for |
+| --- | --- |
+| `FRESHNESS` | Stale or late-arriving data |
+| `VOLUME` | Unexpected row counts |
+| `FIELD` | Bad or invalid column values |
+| `SQL` | A failed query |
+| `DATA_SCHEMA` | Unexpected schema change |
+| `OPERATIONAL` | Pipeline or job failure |
+| `CUSTOM` | Anything else |
+
+## Notes
+
+This is an illustrative example, not production code. In particular, it creates
+an incident on every request without deduplicating against existing open
+incidents for the same dataset.

--- a/examples/langchain_incident_agent/agent.py
+++ b/examples/langchain_incident_agent/agent.py
@@ -1,0 +1,45 @@
+import sys
+
+from langchain.agents import create_agent
+from langchain_ollama import ChatOllama
+from tools import create_datahub_incident
+
+MODEL = "qwen3:8b"
+
+SYSTEM_PROMPT = """You are a data reliability assistant.
+
+When a user reports that a dataset or pipeline is unhealthy, file an incident in
+DataHub using the create_datahub_incident tool. Pick the incident_type that best
+matches the symptom: stale or late data is FRESHNESS, an unexpected row count is
+VOLUME, a pipeline or job failure is OPERATIONAL.
+
+The tool needs a full dataset URN. If the user only gives you a name, say so and
+ask for the URN instead of guessing one.
+"""
+
+
+def run_incident_agent(query: str) -> str:
+
+    llm = ChatOllama(model=MODEL)
+
+    agent = create_agent(
+        model=llm,
+        tools=[create_datahub_incident],
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    print(f"Executing agent for query: {query}")
+    result = agent.invoke({"messages": [{"role": "user", "content": query}]})
+    return result["messages"][-1].content
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        test_query = " ".join(sys.argv[1:])
+    else:
+        test_query = (
+            "The dataset urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+            "showcase.ecommerce.orders,PROD) is stale. Please log an incident."
+        )
+
+    print(run_incident_agent(test_query))

--- a/examples/langchain_incident_agent/agent.py
+++ b/examples/langchain_incident_agent/agent.py
@@ -34,12 +34,18 @@ def run_incident_agent(query: str) -> str:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        test_query = " ".join(sys.argv[1:])
-    else:
-        test_query = (
-            "The dataset urn:li:dataset:(urn:li:dataPlatform:snowflake,"
-            "showcase.ecommerce.orders,PROD) is stale. Please log an incident."
+    if len(sys.argv) <= 1:
+        # Dataset URNs are instance-specific, so there is no sample query that
+        # works everywhere. Point the user at their own instance instead.
+        print(
+            "Usage: python agent.py <your request, including a dataset URN>\n\n"
+            "Example:\n"
+            '  python agent.py "The dataset urn:li:dataset:'
+            "(urn:li:dataPlatform:snowflake,db.schema.orders,PROD) "
+            'is stale. Please log an incident."\n\n'
+            "Find real dataset URNs in your DataHub UI, or run:\n"
+            "  datahub search --entity dataset\n"
         )
+        raise SystemExit(1)
 
-    print(run_incident_agent(test_query))
+    print(run_incident_agent(" ".join(sys.argv[1:])))

--- a/examples/langchain_incident_agent/requirements.txt
+++ b/examples/langchain_incident_agent/requirements.txt
@@ -1,0 +1,3 @@
+langchain>=1.0,<2
+langchain-ollama>=1.0,<2
+acryl-datahub>=1.0

--- a/examples/langchain_incident_agent/tools.py
+++ b/examples/langchain_incident_agent/tools.py
@@ -7,6 +7,7 @@ import uuid
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
 from datahub.metadata.schema_classes import (
     AuditStampClass,
     IncidentInfoClass,
@@ -46,6 +47,16 @@ def _make_emitter() -> DatahubRestEmitter:
     return DatahubRestEmitter(gms_server, token=gms_token)
 
 
+def _make_graph() -> DataHubGraph:
+    """Read-side client, configured from the same env vars as the emitter."""
+    return DataHubGraph(
+        DatahubClientConfig(
+            server=os.getenv("DATAHUB_GMS_URL", "http://localhost:8080"),
+            token=os.getenv("DATAHUB_GMS_TOKEN"),
+        )
+    )
+
+
 @tool
 def create_datahub_incident(
     dataset_urn: str,
@@ -82,6 +93,19 @@ def create_datahub_incident(
             f"Error: {dataset_urn!r} is not a valid DataHub URN. "
             "Look up the dataset's full URN before filing an incident."
         )
+
+    # A syntactically valid URN can still point at nothing. Without this check
+    # the emitter accepts an incident for a non-existent dataset and the tool
+    # reports success, leaving an orphaned incident and no visible error.
+    try:
+        if not _make_graph().exists(dataset_urn):
+            return (
+                f"Error: no dataset found in DataHub with URN {dataset_urn!r}. "
+                "Search DataHub for the correct URN before filing an incident."
+            )
+    except Exception as e:
+        logger.exception("Could not verify dataset %s exists", dataset_urn)
+        return f"Error: could not verify the dataset exists in DataHub: {e}"
 
     actor = os.getenv("DATAHUB_ACTOR_URN", DEFAULT_ACTOR)
     now = AuditStampClass(time=_now_millis(), actor=actor)

--- a/examples/langchain_incident_agent/tools.py
+++ b/examples/langchain_incident_agent/tools.py
@@ -1,0 +1,116 @@
+"""LangChain tools for filing DataHub incidents."""
+
+import logging
+import os
+import time
+import uuid
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.rest_emitter import DatahubRestEmitter
+from datahub.metadata.schema_classes import (
+    AuditStampClass,
+    IncidentInfoClass,
+    IncidentSourceClass,
+    IncidentSourceTypeClass,
+    IncidentStateClass,
+    IncidentStatusClass,
+    IncidentTypeClass,
+)
+from datahub.metadata.urns import IncidentUrn
+from langchain.tools import tool
+
+logger = logging.getLogger(__name__)
+
+# Incident categories the agent is allowed to choose from. These mirror the
+# enum values in datahub.metadata.schema_classes.IncidentTypeClass.
+INCIDENT_TYPES = {
+    "FRESHNESS": IncidentTypeClass.FRESHNESS,
+    "VOLUME": IncidentTypeClass.VOLUME,
+    "FIELD": IncidentTypeClass.FIELD,
+    "SQL": IncidentTypeClass.SQL,
+    "DATA_SCHEMA": IncidentTypeClass.DATA_SCHEMA,
+    "OPERATIONAL": IncidentTypeClass.OPERATIONAL,
+    "CUSTOM": IncidentTypeClass.CUSTOM,
+}
+
+DEFAULT_ACTOR = "urn:li:corpuser:datahub"
+
+
+def _now_millis() -> int:
+    return int(time.time() * 1000)
+
+
+def _make_emitter() -> DatahubRestEmitter:
+    gms_server = os.getenv("DATAHUB_GMS_URL", "http://localhost:8080")
+    gms_token = os.getenv("DATAHUB_GMS_TOKEN")
+    return DatahubRestEmitter(gms_server, token=gms_token)
+
+
+@tool
+def create_datahub_incident(
+    dataset_urn: str,
+    title: str,
+    description: str,
+    incident_type: str = "OPERATIONAL",
+) -> str:
+    """Raise an incident against a DataHub dataset so its owners are notified.
+
+    Use this when a dataset or pipeline is reported as broken, stale, empty, or
+    otherwise unhealthy.
+
+    Args:
+        dataset_urn: Full URN of the affected dataset, e.g.
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)".
+        title: Short one-line summary of the problem.
+        description: Detailed explanation, including any symptoms observed.
+        incident_type: One of FRESHNESS (stale/late data), VOLUME (row count
+            anomaly), FIELD (bad column values), SQL (failed query), DATA_SCHEMA
+            (schema change), OPERATIONAL (pipeline/job failure), or CUSTOM.
+
+    Returns:
+        A message describing whether the incident was created.
+    """
+    resolved_type = INCIDENT_TYPES.get(incident_type.upper())
+    if resolved_type is None:
+        return (
+            f"Error: unknown incident_type {incident_type!r}. "
+            f"Choose one of: {', '.join(sorted(INCIDENT_TYPES))}."
+        )
+
+    if not dataset_urn.startswith("urn:li:"):
+        return (
+            f"Error: {dataset_urn!r} is not a valid DataHub URN. "
+            "Look up the dataset's full URN before filing an incident."
+        )
+
+    actor = os.getenv("DATAHUB_ACTOR_URN", DEFAULT_ACTOR)
+    now = AuditStampClass(time=_now_millis(), actor=actor)
+    incident_urn = IncidentUrn(uuid.uuid4().hex)
+
+    incident_info = IncidentInfoClass(
+        type=resolved_type,
+        entities=[dataset_urn],
+        title=title,
+        description=description,
+        status=IncidentStatusClass(
+            state=IncidentStateClass.ACTIVE,
+            lastUpdated=now,
+        ),
+        created=now,
+        source=IncidentSourceClass(type=IncidentSourceTypeClass.MANUAL),
+    )
+
+    mcp = MetadataChangeProposalWrapper(
+        entityUrn=str(incident_urn),
+        aspect=incident_info,
+    )
+
+    try:
+        _make_emitter().emit(mcp)
+    except Exception as e:
+        # Return the failure to the agent rather than raising, so it can
+        # report the problem instead of crashing mid-run.
+        logger.exception("Failed to emit incident for %s", dataset_urn)
+        return f"Error: could not create the incident in DataHub: {e}"
+
+    return f"Success! Incident {incident_urn} created for dataset {dataset_urn}."


### PR DESCRIPTION
Adding a LangChain agent example that uses a custom tool to write incidents back to DataHub, complementing the MCP read tools. Built for the DataHub Agent Hackathon.

Note: I have verified the imports and tool schema, but have not executed this end-to-end against a live GMS instance yet.

Also adds `.DS_Store` to `.gitignore`, and brings `examples/` under ruff
format/lint via `PY_FILES`. mypy is scoped to a new `MYPY_FILES` variable
that excludes `examples/`, since the example's dependencies (langchain,
langchain-ollama) are deliberately not in this project's dev environment
and would otherwise break `make lint`.