### PR TITLE
fix(lineage): get_lineage docstring documents a `count` param that doesn't exist

### DIFF
--- a/src/mcp_server_datahub/tools/lineage.py
+++ b/src/mcp_server_datahub/tools/lineage.py
@@ -255,16 +255,16 @@ def get_lineage(
     - Find Looker dashboards in lineage: query="/q tag:looker"
     - Get all results: query="*" or omit parameter
 
-    COUNT PARAMETER - Control result size:
+    MAX_RESULTS PARAMETER - Control result size:
     - Default: 30 results
-    - For aggregation: count=30 is sufficient (facets computed on ALL items server-side)
-    - For finding specific item: Increase count or use query to filter
-    - Example: count=100 for larger result sets
+    - For aggregation: max_results=30 is sufficient (facets computed on ALL items server-side)
+    - For finding specific item: Increase max_results or use query to filter
+    - Example: max_results=100 for larger result sets
 
-    WHEN TO USE QUERY vs COUNT:
+    WHEN TO USE QUERY vs MAX_RESULTS:
     - User asks "is X affected?" -> Use query to filter for X specifically
-    - Large lineage (>30 items) -> Keep count=30, use facets for aggregation
-    - Need complete list -> Increase count only if total <=100
+    - Large lineage (>30 items) -> Keep max_results=30, use facets for aggregation
+    - Need complete list -> Increase max_results only if total <=100
     """
     # Normalize column parameter: Some LLMs pass the string "null" instead of JSON null.
     # Note: This means columns literally named "null" cannot be queried.


### PR DESCRIPTION
## What

`get_lineage`'s docstring has a `COUNT PARAMETER` section telling the caller to raise `count` to get more results:

```
COUNT PARAMETER - Control result size:
- Default: 30 results
- For aggregation: count=30 is sufficient (facets computed on ALL items server-side)
- For finding specific item: Increase count or use query to filter
- Example: count=100 for larger result sets
```

But the signature has no `count` — the knob is `max_results`:

```python
def get_lineage(
    urn: str,
    column: Optional[str] = None,
    query: Optional[str] = None,
    filter: Optional[str] = None,
    upstream: bool = True,
    max_hops: int = 1,
    max_results: int = 30,
    offset: int = 0,
) -> dict:
```

So `get_lineage(urn=..., count=100)` fails validation, and the same docstring already says `max_results` a dozen lines earlier under `PAGINATION` — an agent reading it top-to-bottom is handed two names for one parameter and picks the one in the section literally headed "Control result size".

The wrong name is also plausible rather than obviously wrong: `count` *is* a real parameter on `get_dataset_queries` and `get_dataset_assertions`, so a model that has seen those tools has no reason to doubt it here.

## Change

Docstring only — `count` → `max_results` in the two affected sections. No behaviour change.

## How I found it

I hit this building an agent against this server for the DataHub Agent Hackathon: the model kept passing `count` to `get_lineage` and getting validation errors, and the tool description was the reason.

I also statically checked every other tool docstring in `src/mcp_server_datahub/tools/` for keyword names that don't exist on the corresponding signature — `get_lineage` was the only real hit. The remaining matches are all filter-DSL expressions (`platform = notion`) or example variable assignments, not parameter names.

## Checks

- `ruff check` and `ruff format --check` pass on the changed file.
- No test added: `make test` needs a live DataHub instance, and this is a docstring-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Rh9Q3CfGQZXQAk7iqqUt