### PR TITLE
fix(filters): tell the caller what to do about an empty IN list

### DIFF
--- a/src/mcp_server_datahub/search_filter_parser.py
+++ b/src/mcp_server_datahub/search_filter_parser.py
@@ -28,8 +28,6 @@ Known limitations:
     - Field names that collide with SQL keywords (``in``, ``not``, ``and``,
       ``or``) cannot be used as field names.  No real DataHub fields have
       these names.
-    - ``platform IN ()`` (empty IN list) produces a confusing parse error
-      rather than a clear message.
     - ``status`` only accepts a single value (NOT_SOFT_DELETED, ALL, or
       ONLY_SOFT_DELETED) because ``RemovedStatusFilter`` is an enum.
     - LIKE / CONTAINS operators are not supported; fall back to the JSON
@@ -410,7 +408,17 @@ class _Parser:
             return F.custom_filter(field, self._COMPARISON_OPS[op_token.type], [value])
         elif self._peek().type == _TokenType.IN:
             self._advance()  # consume IN
-            self._expect(_TokenType.LPAREN)
+            lparen = self._expect(_TokenType.LPAREN)
+            if self._peek().type == _TokenType.RPAREN:
+                # Reached by a caller that interpolated a list which turned out
+                # to be empty. The generic "expected value, got )" is accurate
+                # and tells them nothing about what to do instead.
+                raise ValueError(
+                    f"Empty IN list for field {field!r} at position {lparen.pos}: "
+                    f"IN needs at least one value. An empty list usually means the "
+                    f"values were computed and came back empty — drop the condition "
+                    f"rather than sending it, since IN () cannot match anything."
+                )
             values = [self._expect_value().value]
             while self._peek().type == _TokenType.COMMA:
                 self._advance()  # consume comma

--- a/tests/test_mcp/test_search_filter_parser.py
+++ b/tests/test_mcp/test_search_filter_parser.py
@@ -1,0 +1,39 @@
+"""Tests for the SQL-like filter parser's error messages.
+
+The caller here is usually a model, and it cannot ask a follow-up question. A
+parse error is the only feedback it gets, so an error that names the problem but
+not the fix costs a whole retry — or several, if the model keeps rephrasing a
+filter that was never the problem.
+"""
+
+import pytest
+
+from mcp_server_datahub.search_filter_parser import parse_filter_string
+
+
+def test_empty_in_list_says_what_to_do_instead():
+    """An empty IN list is a caller that interpolated an empty collection."""
+    with pytest.raises(ValueError) as exc:
+        parse_filter_string("platform IN ()")
+
+    message = str(exc.value)
+    assert "Empty IN list" in message
+    assert "platform" in message, "the message should name the offending field"
+    assert "drop the condition" in message
+
+
+def test_empty_in_list_with_whitespace_is_still_empty():
+    with pytest.raises(ValueError, match="Empty IN list"):
+        parse_filter_string("entity_type IN ( )")
+
+
+def test_a_single_value_in_list_is_fine():
+    """The empty check must not swallow the smallest valid list."""
+    parse_filter_string("platform IN (snowflake)")
+
+
+def test_a_trailing_comma_is_still_a_missing_value_not_an_empty_list():
+    """`IN (a,)` is a different mistake and should not claim the list is empty."""
+    with pytest.raises(ValueError) as exc:
+        parse_filter_string("platform IN (snowflake,)")
+    assert "Empty IN list" not in str(exc.value)


### PR DESCRIPTION
## What

`platform IN ()` currently raises:

```
Expected value at position 13, got ) (')')
```

Accurate, and useless. It names the token the parser wanted, not the mistake the caller made. `search_filter_parser.py`'s own docstring already lists this under **Known limitations**:

> `platform IN ()` (empty IN list) produces a confusing parse error rather than a clear message.

This removes that bullet by fixing it.

## Why it matters more here than in a hand-written query

The caller is usually a model, and it is usually interpolating a list it computed a moment ago — platforms from a facet, tags from a previous search. When that list comes back empty, the right move is to **drop the condition**, because an empty `IN` cannot match anything. Nothing in the old message points there, so the model does the only thing the message suggests: rephrases a filter that was never the problem, and burns a round trip or three doing it.

A parse error is the only feedback an MCP caller gets. It has no way to ask a follow-up question.

## After

```
Empty IN list for field 'platform' at position 12: IN needs at least one value.
An empty list usually means the values were computed and came back empty — drop
the condition rather than sending it, since IN () cannot match anything.
```

## Scope

- The check fires only on an immediate `)` after `(`, so `IN (snowflake)` and `IN (a, b)` are untouched.
- A trailing comma, `IN (a,)`, is a *different* mistake — a missing value, not an empty list — and deliberately still gets the generic message. Mislabelling it would trade one confusing error for another. There is a test pinning that.

## Tests

New `tests/test_mcp/test_search_filter_parser.py` — 4 tests, no live DataHub needed:

```
4 passed
```

Covers: the message names the field and the fix; whitespace-only `IN ( )` counts as empty; a single-value list still parses; a trailing comma is not reported as an empty list.

`ruff check` and `ruff format --check` pass on both changed files.

## Context

Second small fix from building an agent against this server for the DataHub Agent Hackathon; the first was #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Rh9Q3CfGQZXQAk7iqqUt