### PR TITLE
feat: add raise_incident mutation tool

### DIFF
--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -71,6 +71,7 @@ from .tools.documents import grep_documents, search_documents
 from .tools.domains import remove_domains, set_domains
 from .tools.entities import get_entities, list_schema_fields
 from .tools.get_me import get_me
+from .tools.incidents import raise_incident
 from .tools.lineage import (  # noqa: F401 (re-exported for backward compat)
     AssetLineageAPI,
     AssetLineageDirective,
@@ -256,6 +257,9 @@ def register_mutation_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None
     )
     _register_tool(
         mcp_instance, "remove_domains", remove_domains, tags={ToolType.MUTATION.value}
+    )
+    _register_tool(
+        mcp_instance, "raise_incident", raise_incident, tags={ToolType.MUTATION.value}
     )
     _register_tool(mcp_instance, "update_description", update_description)
     _register_tool(mcp_instance, "add_structured_properties", add_structured_properties)

--- a/src/mcp_server_datahub/tools/incidents.py
+++ b/src/mcp_server_datahub/tools/incidents.py
@@ -1,0 +1,182 @@
+"""Incident management tools for DataHub MCP server."""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from datahub.metadata.schema_classes import IncidentInfoClass, IncidentTypeClass
+from datahub.metadata.urns import Urn
+
+from .. import graphql_helpers
+
+logger = logging.getLogger(__name__)
+
+RAISE_INCIDENT_MUTATION = """
+mutation raiseIncident($input: RaiseIncidentInput!) {
+  raiseIncident(input: $input)
+}
+"""
+
+#: Values accepted by the GraphQL ``IncidentPriority`` enum. Note this is an enum
+#: name and not the integer the ``incidentInfo`` aspect stores underneath.
+VALID_PRIORITIES = ("LOW", "MEDIUM", "HIGH", "CRITICAL")
+
+
+def _valid_incident_types() -> frozenset:
+    """Return every incident type the installed metadata model accepts.
+
+    Read off the enum rather than hardcoded, so the tool cannot drift from the
+    server it is talking to. Note there is no ``COLUMN`` type: the column-scoped
+    one is ``FIELD``.
+    """
+    return frozenset(
+        value
+        for name, value in vars(IncidentTypeClass).items()
+        if not name.startswith("_") and isinstance(value, str)
+    )
+
+
+def _valid_entity_types() -> frozenset:
+    """Return the entity types an incident may attach to.
+
+    Read off the ``incidentInfo`` aspect's own relationship annotation, for the
+    same no-drift reason as :func:`_valid_incident_types`. Notably this does not
+    include ``mlModel``: GMS rejects one with a 500.
+    """
+    schema = json.loads(str(IncidentInfoClass.RECORD_SCHEMA))
+    for field in schema["fields"]:
+        if field["name"] == "entities":
+            return frozenset(field["Relationship"]["/*"]["entityTypes"])
+    raise RuntimeError(
+        "incidentInfo has no 'entities' field; the metadata model changed"
+    )
+
+
+def _validate_resource_urn(resource_urn: str) -> None:
+    """Validate that an incident can actually be attached to this entity.
+
+    Raises:
+        ValueError: The URN is malformed, or names an entity type that cannot
+            carry an incident.
+    """
+    try:
+        entity_type = Urn.from_string(resource_urn).entity_type
+    except Exception as e:
+        raise ValueError(
+            f"{resource_urn!r} is not a valid DataHub URN: {e}. "
+            f"Use the search tool to find the entity you want to raise an incident on."
+        ) from e
+
+    allowed = _valid_entity_types()
+    if entity_type not in allowed:
+        raise ValueError(
+            f"DataHub cannot raise an incident on a {entity_type}. "
+            f"Allowed entity types: {', '.join(sorted(allowed))}. "
+            f"Attach the incident to the dataset or schemaField the problem concerns."
+        )
+
+
+def raise_incident(
+    resource_urn: str,
+    title: str,
+    description: str,
+    incident_type: str = "CUSTOM",
+    priority: Optional[str] = None,
+) -> dict:
+    """Raise an incident on a DataHub entity to record a data quality problem.
+
+    Use this to record a problem you have found so it is visible to the asset's
+    owners and to the next agent or person who looks at it. An incident is the
+    durable, catalog-native way to say "this asset is currently broken", as
+    opposed to a tag or a description edit.
+
+    The incident is created in the ACTIVE state and appears on the entity's
+    Incidents tab in the DataHub UI.
+
+    Args:
+        resource_urn: URN of the entity to raise the incident on (e.g. a dataset
+            or schemaField URN). Note that an mlModel cannot carry an incident;
+            attach it to the dataset the model consumes instead.
+        title: Short, human-readable summary of the problem
+            (e.g. "orders_raw has not refreshed in 30 hours").
+        description: The incident body. Include what was observed, how it was
+            measured, and what the impact is.
+        incident_type: One of the DataHub incident types, e.g. "FRESHNESS",
+            "DATA_SCHEMA", "FIELD", "OPERATIONAL", "CUSTOM" (default "CUSTOM").
+        priority: Optional priority, one of "LOW", "MEDIUM", "HIGH", "CRITICAL".
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - urn: The URN of the newly created incident
+        - message: Success message
+
+    Examples:
+        # Record a stale table
+        raise_incident(
+            resource_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.public.orders_raw,PROD)",
+            title="orders_raw has not refreshed in 30 hours",
+            description="Last operation was 30h ago against a 6h freshness SLA.",
+            incident_type="FRESHNESS",
+            priority="HIGH",
+        )
+
+        # Record a column-level problem
+        raise_incident(
+            resource_urn="urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,db.public.users,PROD),email)",
+            title="email is 40% null after the latest load",
+            description="Null rate moved from 0.1% to 40% between runs.",
+            incident_type="FIELD",
+        )
+    """
+    client = graphql_helpers.get_datahub_client()
+
+    if not title or not title.strip():
+        raise ValueError("title cannot be empty")
+    if not description or not description.strip():
+        raise ValueError("description cannot be empty")
+
+    allowed_types = _valid_incident_types()
+    if incident_type not in allowed_types:
+        raise ValueError(
+            f"{incident_type!r} is not a DataHub incident type. "
+            f"Allowed types: {', '.join(sorted(allowed_types))}."
+        )
+
+    if priority is not None and priority not in VALID_PRIORITIES:
+        raise ValueError(
+            f"{priority!r} is not a valid incident priority. "
+            f"Allowed priorities: {', '.join(VALID_PRIORITIES)}."
+        )
+
+    _validate_resource_urn(resource_urn)
+
+    incident_input: Dict[str, Any] = {
+        "resourceUrn": resource_urn,
+        "type": incident_type,
+        "title": title,
+        "description": description,
+    }
+    if priority is not None:
+        incident_input["priority"] = priority
+
+    result = graphql_helpers.execute_graphql(
+        client._graph,
+        query=RAISE_INCIDENT_MUTATION,
+        variables={"input": incident_input},
+        operation_name="raiseIncident",
+    )
+
+    incident_urn = result.get("raiseIncident")
+    if not incident_urn:
+        raise ValueError(
+            f"raiseIncident returned no URN for {resource_urn}. Response: {result}"
+        )
+
+    logger.info(f"Raised incident {incident_urn} on {resource_urn}")
+
+    return {
+        "success": True,
+        "urn": incident_urn,
+        "message": f"Raised {incident_type} incident on {resource_urn}",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ if using_oss:
 
     assertions_module = sys.modules["mcp_server_datahub.tools.assertions"]
     dataset_queries_module = sys.modules["mcp_server_datahub.tools.dataset_queries"]
+    incidents_module = sys.modules["mcp_server_datahub.tools.incidents"]
     entities_module = sys.modules["mcp_server_datahub.tools.entities"]
     lineage_module = sys.modules["mcp_server_datahub.tools.lineage"]
     search_module = sys.modules["mcp_server_datahub.tools.search"]
@@ -139,6 +140,7 @@ if using_oss:
     tools_module.domains = domains_module  # type: ignore[attr-defined]
     tools_module.entities = entities_module  # type: ignore[attr-defined]
     tools_module.get_me = get_me_module  # type: ignore[attr-defined]
+    tools_module.incidents = incidents_module  # type: ignore[attr-defined]
     tools_module.lineage = lineage_module  # type: ignore[attr-defined]
     tools_module.owners = owners_module  # type: ignore[attr-defined]
     tools_module.save_document = save_document_module  # type: ignore[attr-defined]
@@ -156,6 +158,7 @@ if using_oss:
     sys.modules["datahub_integrations.mcp.tools.domains"] = domains_module
     sys.modules["datahub_integrations.mcp.tools.entities"] = entities_module
     sys.modules["datahub_integrations.mcp.tools.get_me"] = get_me_module
+    sys.modules["datahub_integrations.mcp.tools.incidents"] = incidents_module
     sys.modules["datahub_integrations.mcp.tools.lineage"] = lineage_module
     sys.modules["datahub_integrations.mcp.tools.owners"] = owners_module
     sys.modules["datahub_integrations.mcp.tools.save_document"] = save_document_module

--- a/tests/test_mcp/tools/test_incidents.py
+++ b/tests/test_mcp/tools/test_incidents.py
@@ -1,0 +1,184 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_integrations.mcp.tools.incidents import (
+    _valid_entity_types,
+    _valid_incident_types,
+    raise_incident,
+)
+
+DATASET_URN = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders_raw,PROD)"
+FIELD_URN = f"urn:li:schemaField:({DATASET_URN},email)"
+MODEL_URN = "urn:li:mlModel:(urn:li:dataPlatform:mlflow,credit_risk_v3,PROD)"
+
+
+@pytest.fixture
+def mock_datahub_client():
+    """Fixture for mocking DataHubClient."""
+    mock_client = Mock()
+    mock_graph = Mock()
+    mock_client._graph = mock_graph
+    return mock_client
+
+
+def _patched_client(mock_datahub_client):
+    return patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    )
+
+
+def test_raise_incident_on_dataset(mock_datahub_client):
+    """Test raising an incident on a dataset."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": "urn:li:incident:abc-123"
+    }
+
+    with _patched_client(mock_datahub_client):
+        result = raise_incident(
+            resource_urn=DATASET_URN,
+            title="orders_raw has not refreshed in 30 hours",
+            description="Last operation was 30h ago against a 6h freshness SLA.",
+            incident_type="FRESHNESS",
+        )
+
+    assert result["success"] is True
+    assert result["urn"] == "urn:li:incident:abc-123"
+
+    call_kwargs = mock_datahub_client._graph.execute_graphql.call_args.kwargs
+    assert call_kwargs["variables"]["input"] == {
+        "resourceUrn": DATASET_URN,
+        "type": "FRESHNESS",
+        "title": "orders_raw has not refreshed in 30 hours",
+        "description": "Last operation was 30h ago against a 6h freshness SLA.",
+    }
+
+
+def test_raise_incident_on_schema_field(mock_datahub_client):
+    """Test raising a column-scoped incident on a schemaField."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": "urn:li:incident:def-456"
+    }
+
+    with _patched_client(mock_datahub_client):
+        result = raise_incident(
+            resource_urn=FIELD_URN,
+            title="email is 40% null",
+            description="Null rate moved from 0.1% to 40%.",
+            incident_type="FIELD",
+        )
+
+    assert result["success"] is True
+    assert result["urn"] == "urn:li:incident:def-456"
+
+
+def test_priority_is_passed_as_enum_name(mock_datahub_client):
+    """Priority is a GraphQL enum name, not the integer the aspect stores."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": "urn:li:incident:ghi-789"
+    }
+
+    with _patched_client(mock_datahub_client):
+        raise_incident(
+            resource_urn=DATASET_URN,
+            title="t",
+            description="d",
+            priority="HIGH",
+        )
+
+    call_kwargs = mock_datahub_client._graph.execute_graphql.call_args.kwargs
+    assert call_kwargs["variables"]["input"]["priority"] == "HIGH"
+
+
+def test_priority_is_omitted_when_not_given(mock_datahub_client):
+    """An unset priority is left out of the payload rather than sent as null."""
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "raiseIncident": "urn:li:incident:jkl-012"
+    }
+
+    with _patched_client(mock_datahub_client):
+        raise_incident(resource_urn=DATASET_URN, title="t", description="d")
+
+    call_kwargs = mock_datahub_client._graph.execute_graphql.call_args.kwargs
+    assert "priority" not in call_kwargs["variables"]["input"]
+
+
+def test_ml_model_is_rejected_with_an_actionable_message(mock_datahub_client):
+    """An mlModel cannot carry an incident; GMS answers a 500 for one."""
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="cannot raise an incident on a mlModel"):
+            raise_incident(resource_urn=MODEL_URN, title="t", description="d")
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+def test_unknown_incident_type_is_rejected(mock_datahub_client):
+    """COLUMN looks plausible but is not a type; the column-scoped one is FIELD."""
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="is not a DataHub incident type"):
+            raise_incident(
+                resource_urn=DATASET_URN,
+                title="t",
+                description="d",
+                incident_type="COLUMN",
+            )
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+def test_unknown_priority_is_rejected(mock_datahub_client):
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="is not a valid incident priority"):
+            raise_incident(
+                resource_urn=DATASET_URN,
+                title="t",
+                description="d",
+                priority="URGENT",
+            )
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+def test_malformed_urn_is_rejected(mock_datahub_client):
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="is not a valid DataHub URN"):
+            raise_incident(resource_urn="not-a-urn", title="t", description="d")
+
+    mock_datahub_client._graph.execute_graphql.assert_not_called()
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_title_is_rejected(mock_datahub_client, blank):
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="title cannot be empty"):
+            raise_incident(resource_urn=DATASET_URN, title=blank, description="d")
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_description_is_rejected(mock_datahub_client, blank):
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="description cannot be empty"):
+            raise_incident(resource_urn=DATASET_URN, title="t", description=blank)
+
+
+def test_a_response_without_a_urn_is_an_error(mock_datahub_client):
+    """A mutation that ran but returned nothing must not read as success."""
+    mock_datahub_client._graph.execute_graphql.return_value = {"raiseIncident": None}
+
+    with _patched_client(mock_datahub_client):
+        with pytest.raises(ValueError, match="returned no URN"):
+            raise_incident(resource_urn=DATASET_URN, title="t", description="d")
+
+
+def test_valid_sets_come_from_the_installed_metadata_model():
+    """The allowed sets are derived, so they cannot drift from the server."""
+    types = _valid_incident_types()
+    assert "FRESHNESS" in types
+    assert "FIELD" in types
+    assert "COLUMN" not in types
+
+    entities = _valid_entity_types()
+    assert "dataset" in entities
+    assert "schemaField" in entities
+    assert "mlModel" not in entities


### PR DESCRIPTION
## The gap

The server can read a data quality problem but cannot record one. There are tools for tags, terms, owners, domains, descriptions, structured properties and documents, but none for incidents, so an agent that finds a stale table or a broken column has nowhere durable to put the finding. An incident is the catalog-native way to say "this asset is currently broken", and it is the one write an automated data-quality agent most needs.

This adds a single `raise_incident` tool, registered alongside the other mutation tools and gated behind the same `TOOLS_IS_MUTATION_ENABLED` flag.

## Design notes

**The allowed sets are derived, not hardcoded.** `_valid_incident_types()` reads `IncidentTypeClass` and `_valid_entity_types()` reads the `incidentInfo` aspect's own relationship annotation. Neither can drift from the server the tool is talking to, and both produce better errors than GMS does:

- An `mlModel` cannot carry an incident (GMS answers a 500). The tool rejects it before the call and names the dataset or `schemaField` to attach it to instead. This is the single most common mistake when wiring an ML-facing agent to DataHub.
- `COLUMN` looks like a plausible incident type and is not one; the column-scoped type is `FIELD`. The error lists the real set.

**`priority` is the GraphQL enum name, not the stored integer.** `RaiseIncidentInput.priority` is `IncidentPriority` (`LOW`/`MEDIUM`/`HIGH`/`CRITICAL`), while the `incidentInfo` aspect stores an integer underneath. Passing `1` fails inside GMS with a validation error that does not explain itself, so the tool validates the enum name up front. This one cost me a debugging round against a live server, which is why it is called out in the docstring.

**Thin on purpose.** `resourceUrns` (batch), `assigneeUrns`, `startedAt` and `status` are all supported by the mutation but left out, to keep the first version of the tool small. Happy to add any of them if you would rather it land complete.

## Testing

14 unit tests in `tests/test_mcp/tools/test_incidents.py` covering the payload shape, the enum handling, every validation path, and the derived-set invariants. `tests/conftest.py` gains the `incidents` entry in the cross-repo compatibility shim, matching the existing pattern.

```
uv run pytest tests/test_mcp -q     513 passed
make lint-check                     ruff + mypy clean
```

Also verified end to end against a live OSS Quickstart (GMS 1.5.0.6), driving the server over stdio with a real MCP client:

- `raise_incident` on a dataset returns `{"success": true, "urn": "urn:li:incident:..."}`, and the incident reads back from GMS with the expected type, title, entities and `ACTIVE` state.
- `priority: "HIGH"` round-trips and stores as the expected integer in the aspect.
- The `mlModel`, unknown-type, unknown-priority, malformed-URN and blank-title paths each return their actionable message and issue no GraphQL call.

## Context

Written while building an ML reliability agent on DataHub OSS, where the missing incident write was the one gap that forced going around the MCP server to the GraphQL API directly. There is a related question about whether ML entities should be able to carry incidents at all, which I have written up separately as an RFC and am happy to open as a discussion if it is useful.