### PR TITLE
feat(lineage): expose optional skip_cache for get_lineage

### DIFF
--- a/src/mcp_server_datahub/tools/lineage.py
+++ b/src/mcp_server_datahub/tools/lineage.py
@@ -27,6 +27,7 @@ class AssetLineageDirective(BaseModel):
     max_hops: int
     extra_filters: Optional[Filter]
     max_results: int
+    skip_cache: bool = False
 
 
 class AssetLineageAPI:
@@ -70,7 +71,13 @@ class AssetLineageAPI:
             "count": asset_lineage_directive.max_results,
             "types": types,
             "orFilters": compiled_filters,
-            "searchFlags": {"skipHighlighting": True, "maxAggValues": 3},
+            "searchFlags": {
+                "skipHighlighting": True,
+                "maxAggValues": 3,
+                # Only send skipCache when asked. Bypassing the lineage search
+                # cache is slower, so routine exploration keeps the default.
+                **({"skipCache": True} if asset_lineage_directive.skip_cache else {}),
+            },
         }
         if asset_lineage_directive.upstream:
             result["upstreams"] = graphql_helpers.clean_gql_response(
@@ -226,6 +233,7 @@ def get_lineage(
     max_hops: int = 1,
     max_results: int = 30,
     offset: int = 0,
+    skip_cache: bool = False,
 ) -> dict:
     """Get upstream or downstream lineage for any entity, including datasets, schemaFields, dashboards, charts, etc.
 
@@ -265,6 +273,13 @@ def get_lineage(
     - User asks "is X affected?" -> Use query to filter for X specifically
     - Large lineage (>30 items) -> Keep count=30, use facets for aggregation
     - Need complete list -> Increase count only if total <=100
+
+    SKIP_CACHE PARAMETER - Bypass the lineage search cache:
+    - Default: False, which serves cached results and is right for exploration
+    - skip_cache=True re-reads lineage instead of trusting the cache
+    - Use before acting on lineage, for example opening a pull request or
+      writing metadata, where a stale edge would produce a wrong decision
+    - Slower, so prefer the default for routine questions
     """
     # Normalize column parameter: Some LLMs pass the string "null" instead of JSON null.
     # Note: This means columns literally named "null" cannot be queried.
@@ -285,6 +300,7 @@ def get_lineage(
         max_hops=max_hops,
         extra_filters=parsed_filter,
         max_results=max_results,
+        skip_cache=skip_cache,
     )
     lineage = lineage_api.get_lineage(asset_lineage_directive, query=query)
     graphql_helpers.inject_urls_for_urns(

--- a/tests/test_mcp/test_lineage_skip_cache.py
+++ b/tests/test_mcp/test_lineage_skip_cache.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for the get_lineage skip_cache option.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datahub.ingestion.graph.client import DataHubGraph
+
+from mcp_server_datahub.tools.lineage import AssetLineageAPI, AssetLineageDirective
+
+
+@pytest.fixture
+def mock_graph():
+    graph = MagicMock(spec=DataHubGraph)
+    graph._gms_server = "http://localhost:8080"
+    graph.frontend_base_url = "http://localhost:9002"
+    return graph
+
+
+def _directive(**overrides):
+    defaults = dict(
+        urn="urn:li:dataset:(urn:li:dataPlatform:postgres,analytics.orders,PROD)",
+        upstream=False,
+        downstream=True,
+        max_hops=1,
+        extra_filters=None,
+        max_results=30,
+    )
+    defaults.update(overrides)
+    return AssetLineageDirective(**defaults)
+
+
+def _captured_search_flags(mock_graph, directive):
+    empty_result = {"searchAcrossLineage": {"total": 0, "searchResults": []}}
+    with patch(
+        "mcp_server_datahub.tools.lineage.graphql_helpers.execute_graphql",
+        return_value=empty_result,
+    ) as execute:
+        AssetLineageAPI(mock_graph).get_lineage(directive)
+    assert execute.call_count == 1
+    return execute.call_args.kwargs["variables"]["input"]["searchFlags"]
+
+
+def test_lineage_search_is_cached_by_default(mock_graph):
+    """Existing callers must keep today's cached behavior."""
+    search_flags = _captured_search_flags(mock_graph, _directive())
+
+    assert "skipCache" not in search_flags
+    assert search_flags["skipHighlighting"] is True
+
+
+def test_skip_cache_bypasses_the_lineage_search_cache(mock_graph):
+    """skip_cache=True must reach DataHub as searchFlags.skipCache."""
+    search_flags = _captured_search_flags(mock_graph, _directive(skip_cache=True))
+
+    assert search_flags["skipCache"] is True
+    # The existing flags must survive alongside it.
+    assert search_flags["skipHighlighting"] is True
+    assert search_flags["maxAggValues"] == 3


### PR DESCRIPTION
## The problem

`get_lineage` builds `searchFlags` as `{"skipHighlighting": True, "maxAggValues": 3}` and the tool exposes no way to request a cache bypass, so every lineage read goes through DataHub's lineage search cache. Repeating the call or constructing a new client does not help, because the cache is server side.

That is the right default for exploration. It is a problem for an agent that reads lineage and then acts on it.

## Reproduction

While building an agent that opens pull requests based on column lineage, I needed lineage to be trustworthy at the moment before the mutation, not at plan time. In a controlled local graph I removed one downstream lineage edge and immediately re-read:

- `get_lineage` over MCP still returned the removed edge.
- The same query issued directly with `searchFlags.skipCache: true` returned the correct post-removal set.

I restored the graph and re-verified. An agent acting on the first answer would have opened a pull request against a dependency that no longer existed.

DataHub's own lineage UI already passes `skipCache` through `searchFlags`, so the capability exists in the API; it just is not reachable through MCP.

Related, from the server side: datahub-project/datahub#18623 and datahub-project/datahub#18636.

## The change

An opt-in `skip_cache` argument on `get_lineage`, defaulting to `False`:

- `skip_cache: bool = False` on `AssetLineageDirective`
- `searchFlags` gains `skipCache` only when the directive asks for it, leaving `skipHighlighting` and `maxAggValues` untouched
- documented in the existing docstring style: default for exploration, opt in before acting on lineage, slower so not the default

**`False` preserves current behaviour exactly.** No existing caller changes, and a test asserts `skipCache` is absent unless requested.

17 lines in `tools/lineage.py`, plus a new test file.

## Verification

- `503` unit tests pass (`pytest tests/ --ignore=tests/test_mcp_integration.py`), the 501 already present plus the 2 added
- `ruff check` and `ruff format --check` clean
- The 39 errors in `tests/test_mcp_integration.py` are pre-existing and need a live DataHub on `localhost:8080`. I confirmed by stashing this change and reproducing the identical 39 errors on unmodified `main`.

## Open question

A per-call argument seemed least invasive, but if you would rather this were server configuration, or scoped differently, or if bypassing the cache is deliberately withheld because it is expensive on large graphs, I am happy to rework or close it. The goal is that agents doing read-before-write have a supported path rather than each reimplementing a direct GraphQL call.

Motivating consumer, for context only: [RippleProof](https://github.com/itxcrusher/ripple-proof), which re-reads DataHub before opening pull requests and refuses to act when the cached and uncached views disagree.
