### PR TITLE
fix: apply lineage offset at the GraphQL boundary

### DIFF
--- a/src/mcp_server_datahub/tools/lineage.py
+++ b/src/mcp_server_datahub/tools/lineage.py
@@ -27,6 +27,7 @@ class AssetLineageDirective(BaseModel):
     max_hops: int
     extra_filters: Optional[Filter]
     max_results: int
+    offset: int = 0
 
 
 class AssetLineageAPI:
@@ -66,7 +67,7 @@ class AssetLineageAPI:
         variables = {
             "urn": asset_lineage_directive.urn,
             "query": query or "*",
-            "start": 0,
+            "start": asset_lineage_directive.offset,
             "count": asset_lineage_directive.max_results,
             "types": types,
             "orFilters": compiled_filters,
@@ -285,6 +286,7 @@ def get_lineage(
         max_hops=max_hops,
         extra_filters=parsed_filter,
         max_results=max_results,
+        offset=offset,
     )
     lineage = lineage_api.get_lineage(asset_lineage_directive, query=query)
     graphql_helpers.inject_urls_for_urns(
@@ -298,23 +300,12 @@ def get_lineage(
     # Apply offset, entity-level truncation, and cleaning to upstreams/downstreams
     for direction in ["upstreams", "downstreams"]:
         if direction_results := lineage.get(direction):
-            if search_results := direction_results.get("searchResults"):
+            search_results = direction_results.get("searchResults") or []
+            total_available = direction_results.get("total", len(search_results))
+            if search_results:
                 # Extract lineageColumns from paths for column-level lineage
                 search_results = _extract_lineage_columns_from_paths(search_results)
                 direction_results["searchResults"] = search_results
-
-                total_available = len(search_results)
-
-                # Apply offset (skip first N entities)
-                if offset >= total_available:
-                    direction_results["searchResults"] = []
-                    direction_results["offset"] = offset
-                    direction_results["returned"] = 0
-                    direction_results["hasMore"] = False
-                    continue
-
-                # Skip offset and apply token budget using generic helper
-                results_after_offset = search_results[offset:]
 
                 # Lambda to clean entity in place and return it for token counting
                 def get_cleaned_entity(result_item: dict) -> dict:
@@ -326,7 +317,7 @@ def get_lineage(
                 # Get results within budget (entities cleaned in place, degree preserved)
                 selected_results = list(
                     graphql_helpers.select_results_within_budget(
-                        results=iter(results_after_offset),
+                        results=iter(search_results),
                         fetch_entity=get_cleaned_entity,
                         max_results=max_results,
                     )
@@ -340,13 +331,18 @@ def get_lineage(
                     offset + len(selected_results)
                 ) < total_available
 
-                if len(selected_results) < len(results_after_offset):
+                if len(selected_results) < len(search_results):
                     direction_results["truncatedDueToTokenBudget"] = True
 
                 logger.info(
                     f"get_lineage {direction}: Returned {len(selected_results)}/{total_available} entities "
                     f"(offset={offset}, hasMore={direction_results['hasMore']})"
                 )
+            else:
+                direction_results["searchResults"] = []
+                direction_results["offset"] = offset
+                direction_results["returned"] = 0
+                direction_results["hasMore"] = offset < total_available
 
     # Add metadata for column-level lineage responses
     if is_column_level_lineage:

--- a/tests/test_mcp/test_lineage_pagination.py
+++ b/tests/test_mcp/test_lineage_pagination.py
@@ -1,0 +1,53 @@
+"""Regression tests for lineage pagination."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from datahub_integrations.mcp.mcp_server import get_lineage
+
+
+def test_get_lineage_sends_offset_to_graphql() -> None:
+    """A later page must not refetch and locally discard the first page."""
+    graph = SimpleNamespace()
+    client = SimpleNamespace(_graph=graph)
+    search_results = [
+        {
+            "entity": {
+                "urn": f"urn:li:dataset:(urn:li:dataPlatform:test,page2_{index},PROD)"
+            },
+            "degree": 1,
+        }
+        for index in range(5)
+    ]
+
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=client,
+        ),
+        patch(
+            "datahub_integrations.mcp.tools.lineage.graphql_helpers.execute_graphql",
+            return_value={
+                "searchAcrossLineage": {
+                    "searchResults": search_results,
+                    "total": 40,
+                }
+            },
+        ) as execute_graphql,
+        patch(
+            "datahub_integrations.mcp.tools.lineage.graphql_helpers.inject_urls_for_urns"
+        ),
+    ):
+        result = get_lineage(
+            urn="urn:li:dataset:(urn:li:dataPlatform:test,source,PROD)",
+            upstream=True,
+            max_results=5,
+            offset=30,
+        )
+
+    graphql_input = execute_graphql.call_args.kwargs["variables"]["input"]
+    assert graphql_input["start"] == 30
+    assert graphql_input["count"] == 5
+    assert result["upstreams"]["offset"] == 30
+    assert result["upstreams"]["returned"] == 5
+    assert result["upstreams"]["hasMore"] is True


### PR DESCRIPTION
## What changed

- pass `get_lineage.offset` to GraphQL as `SearchAcrossLineageInput.start`
- apply the response token budget to the server-provided page without slicing
  the offset a second time
- derive `hasMore` from GraphQL's total result count
- preserve pagination metadata when a requested page is empty
- add an offline regression test that asserts the actual GraphQL variables and
  page metadata

## Why

Previously, `offset=30, max_results=5` still sent `start: 0, count: 5`. The
client then sliced those five results with `[30:]`, producing an empty page and
`hasMore: false`. An agent enumerating downstream lineage could therefore stop
early and miss consumers.

Closes #194. Related to the broader response-bounding request in #154.

## Validation

```text
make lint-check
Success: no issues found in 36 source files

uv run pytest -q --ignore tests/test_mcp_integration.py
502 passed, 1 warning in 3.34s

uv run pytest tests/test_mcp/test_lineage_pagination.py \
  tests/test_mcp/test_mcp_server_helpers.py -q
62 passed, 1 warning in 0.33s
```

The live integration file could not run locally because no compatible DataHub
GMS was available at `localhost:8080`; CI's OSS and Cloud jobs remain the live
verification boundary.
