### PR TITLE
fix: distinguish deployment-gated tools in logs

### DIFF
--- a/src/mcp_server_datahub/version_requirements.py
+++ b/src/mcp_server_datahub/version_requirements.py
@@ -256,10 +256,16 @@ def filter_tools_by_version(tools: Sequence[T]) -> list[T]:
         else:
             deployment = "cloud" if is_cloud else "oss"
             min_ver = req.cloud_min if is_cloud else req.oss_min
-            logger.info(
-                f"Filtering out tool '{tool_name}': server {deployment} "
-                f"version {server_version} does not meet minimum {min_ver}"
-            )
+            if min_ver is None:
+                logger.info(
+                    f"Filtering out tool '{tool_name}': not available on "
+                    f"{deployment} deployments"
+                )
+            else:
+                logger.info(
+                    f"Filtering out tool '{tool_name}': server {deployment} "
+                    f"version {server_version} does not meet minimum {min_ver}"
+                )
 
     return filtered
 

--- a/tests/test_mcp/test_version_requirements.py
+++ b/tests/test_mcp/test_version_requirements.py
@@ -242,6 +242,24 @@ class TestFilterToolsByVersion:
         result = filter_tools_by_version(mock_tools)
         assert not any(t.name == "search_documents" for t in result)
 
+    @patch("datahub_integrations.mcp.version_requirements.logger.info")
+    @patch("datahub_integrations.mcp.version_requirements._get_server_version_info")
+    def test_deployment_only_tool_logs_unavailable_deployment(
+        self, mock_version_info, mock_log_info, mock_tools, mock_client
+    ):
+        """An absent deployment minimum is not a version shortfall."""
+        TOOL_VERSION_REQUIREMENTS["search_documents"] = VersionRequirement(
+            cloud_min=(0, 3, 16, 0)
+        )
+        mock_version_info.return_value = (False, (1, 6, 0, 0))
+
+        filter_tools_by_version(mock_tools)
+
+        message = mock_log_info.call_args.args[0]
+        assert message == (
+            "Filtering out tool 'search_documents': not available on oss deployments"
+        )
+
     def test_error_fails_open(self, mock_tools):
         """On error fetching server version (e.g., no client), return all tools."""
         TOOL_VERSION_REQUIREMENTS["add_tags"] = VersionRequirement(


### PR DESCRIPTION
## What changed

- distinguish an unsupported deployment type from a genuine minimum-version
  shortfall in version-filter logs
- add a regression test for a Cloud-only tool listed against DataHub Core

## Why

A tool declared with `@min_version(cloud="...")` has no OSS minimum because it
is unavailable on OSS at every version. The current log interpolates that
missing value as if it were a version comparison:

```text
server oss version (1, 6, 0, 0) does not meet minimum None
```

The new message states the actual reason:

```text
not available on oss deployments
```

Closes #192.

## Validation

```text
uv run pytest tests/test_mcp/test_version_requirements.py -q
28 passed, 1 warning in 0.07s

uv run pytest -q --ignore tests/test_mcp_integration.py
502 passed, 1 warning in 3.18s

ruff format/check and mypy on the changed files
passed
```
