### PR TITLE
fix(search): treat sort_by="relevance" as a no-op instead of failing

### DIFF
--- a/src/mcp_server_datahub/tools/search.py
+++ b/src/mcp_server_datahub/tools/search.py
@@ -30,6 +30,17 @@ def _search_implementation(
     # Cap num_results at 50 to prevent excessive requests
     num_results = min(num_results, 50)
 
+    # "relevance" is the *default* ranking, not a sortable field -- no DataHub search
+    # index has a `relevance` mapping to sort on. A caller asking to sort by
+    # relevance (a very natural guess, since it's literally the name of the default
+    # ordering) almost always means "leave the default ranking alone", but forwarding
+    # it verbatim to the backend raises `query_shard_exception: No mapping found for
+    # [relevance] in order to sort on`, which OpenSearch reports as
+    # `all_shards_failed` -- a confusing total search failure for what is, in intent,
+    # a no-op. Normalize it here instead of crashing.
+    if sort_by is not None and sort_by.strip().lower() == "relevance":
+        sort_by = None
+
     parsed_filter = graphql_helpers.parse_filter_input(filter)
 
     types, compiled_filters = compile_filters(parsed_filter)


### PR DESCRIPTION
## What this fixes

`search`'s `sort_by`/`sort_order` parameters are documented (correctly) with a specific allowed-field list per deployment type -- for OSS, just `lastOperationTime`. Nothing in the tool ever mentions `"relevance"` as a valid value, because it isn't a field: it's the name of the *default* ranking.

That's exactly why an LLM tool-calling agent reaches for it anyway. Asking to "sort by relevance" is idiomatic and, from the caller's side, a completely reasonable way to express "give me the best-ranked results" -- indistinguishable in intent from not setting `sort_by` at all.

Forwarded verbatim, DataHub OSS has no `relevance` mapping to sort on, so the query fails outright:

```
query_shard_exception: No mapping found for [relevance] in order to sort on
-> search_phase_execution_exception: all_shards_failed
```

which the client sees as an HTTP 400. That reads exactly like "the search backend is down" -- there's no signal anywhere that a bogus `sort_by` value is the actual cause, and OSS has no default-ranking mapping to fall back to gracefully.

## How I found it

Building an agent against `mcp-server-datahub` on a real DataHub OSS instance (`v1.5.0.6`), the model filled in `sort_by="relevance"` on its own on the very first `search` call, with no prompting toward it -- it's just a natural parameter value to guess. Every subsequent search in that run failed the same way, since nothing invalidated the assumption that the search backend itself was down. I worked around it client-side by stripping `sort_by`/`sort_order` before they reached the server, but that's a workaround for callers who happen to notice; any other MCP client hits the same wall.

## The fix

In `_search_implementation`, treat `sort_by="relevance"` (case-insensitive) as equivalent to not setting `sort_by` at all, before it reaches the GraphQL variables. This is a pure normalization -- every other `sort_by` value, and the no-`sort_by` path, are unchanged.

`make lint-check` passes clean on the changed file. I didn't add an automated test since `DEVELOPING.md` notes the existing suite requires a live DataHub instance I don't have write access to for this fork; happy to add one against whatever fixture/mocking pattern you'd prefer if that's wanted before merge.

## Related

A separate docs-only fix from earlier in the same project: #155 (the `entity_type = report` vs `dashboard`/`dataset` distinction). This one is a behavioral fix rather than a docs clarification -- different bug, same root cause category (an LLM caller's natural-sounding guess isn't validated against what the tool actually accepts).