### PR TITLE
Expose SQL truncation metadata in `get_dataset_queries`

### DIFF
--- a/src/mcp_server_datahub/tools/dataset_queries.py
+++ b/src/mcp_server_datahub/tools/dataset_queries.py
@@ -103,6 +103,12 @@ def get_dataset_queries(
       - urn: Query identifier
       - properties.statement.value: The actual SQL text
       - properties.statement.language: Query language (SQL, etc.)
+      - properties.statement._truncated: Whether the returned SQL text was shortened
+      - properties.statement._originalLengthChars: Original SQL text length
+      - properties.statement._returnedLengthChars: Returned SQL text length, including
+        the truncation suffix when present
+      - properties.statement._fullStatementAvailableVia: A get_entities tool call that
+        retrieves the complete query entity (included only when the SQL text is truncated)
       - properties.source: MANUAL or SYSTEM
       - properties.name: Optional query name
       - platform: Source platform
@@ -121,6 +127,8 @@ def get_dataset_queries(
     - For production analysis: Use source="SYSTEM" to see dashboard/report queries
     - Start with moderate count (5-10) to avoid overwhelming context
     - If no queries found (total=0), proceed without query examples - not all tables have queries
+    - If _truncated is true, call get_entities with the query URN shown in
+      _fullStatementAvailableVia to retrieve the complete statement
     - Parse the SQL statements yourself to find patterns - they are not full-text searchable
     """
     client = graphql_helpers.get_datahub_client()
@@ -157,10 +165,23 @@ def get_dataset_queries(
         if query.get("subjects"):
             query["subjects"] = _deduplicate_subjects(query["subjects"])
 
-        # Truncate long SQL queries to prevent context window issues
+        # Truncate long SQL queries to prevent context window issues. Keep explicit
+        # metadata so callers can distinguish a complete statement from a shortened
+        # one without parsing the human-readable suffix.
         if queryProperties := query.get("properties"):
-            queryProperties["statement"]["value"] = graphql_helpers.truncate_query(
-                queryProperties["statement"]["value"]
-            )
+            statement = queryProperties["statement"]
+            original_value = statement["value"]
+            returned_value = graphql_helpers.truncate_query(original_value)
+
+            statement["value"] = returned_value
+            statement["_truncated"] = returned_value != original_value
+            statement["_originalLengthChars"] = len(original_value)
+            statement["_returnedLengthChars"] = len(returned_value)
+
+            if statement["_truncated"]:
+                statement["_fullStatementAvailableVia"] = {
+                    "tool": "get_entities",
+                    "arguments": {"urns": query["urn"]},
+                }
 
     return graphql_helpers.clean_gql_response(result)

--- a/tests/test_mcp/test_get_dataset_queries.py
+++ b/tests/test_mcp/test_get_dataset_queries.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from datahub_integrations.mcp import graphql_helpers
 from datahub_integrations.mcp.mcp_server import async_background, get_dataset_queries
 
 pytestmark = pytest.mark.anyio
@@ -166,3 +167,61 @@ class TestGetDatasetQueriesParameters:
             if "subjects" in query:
                 # Subjects should be a list of URN strings, not full objects
                 assert isinstance(query["subjects"], list)
+
+    @patch("datahub_integrations.mcp.graphql_helpers.get_datahub_client")
+    @patch("datahub_integrations.mcp.graphql_helpers.execute_graphql")
+    async def test_get_dataset_queries_exposes_non_truncated_statement_metadata(
+        self, mock_execute_graphql, mock_get_client, mock_client, mock_gql_response
+    ):
+        """Short statements include explicit metadata and no full-query hint."""
+        mock_get_client.return_value = mock_client
+        mock_execute_graphql.return_value = mock_gql_response
+
+        result = await async_background(get_dataset_queries)(
+            urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)",
+        )
+
+        for query in result["queries"]:
+            statement = query["properties"]["statement"]
+            assert statement["_truncated"] is False
+            assert statement["_originalLengthChars"] == len(statement["value"])
+            assert statement["_returnedLengthChars"] == len(statement["value"])
+            assert "_fullStatementAvailableVia" not in statement
+
+    @patch("datahub_integrations.mcp.graphql_helpers.get_datahub_client")
+    @patch("datahub_integrations.mcp.graphql_helpers.execute_graphql")
+    async def test_get_dataset_queries_exposes_truncated_statement_metadata(
+        self, mock_execute_graphql, mock_get_client, mock_client, mock_gql_response
+    ):
+        """Long statements report exact lengths and a complete-query retrieval hint."""
+        mock_get_client.return_value = mock_client
+        long_statement = "SELECT * FROM orders WHERE customer_id IS NOT NULL " * 20
+        mock_gql_response["listQueries"]["queries"] = [
+            {
+                "urn": "urn:li:query:long-query",
+                "properties": {
+                    "name": "Long query",
+                    "source": "MANUAL",
+                    "statement": {"value": long_statement, "language": "SQL"},
+                },
+                "platform": {"name": "snowflake"},
+                "subjects": [],
+            }
+        ]
+        mock_execute_graphql.return_value = mock_gql_response
+
+        with patch.object(graphql_helpers, "QUERY_LENGTH_HARD_LIMIT", 50):
+            result = await async_background(get_dataset_queries)(
+                urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)",
+            )
+
+        statement = result["queries"][0]["properties"]["statement"]
+        assert statement["value"].endswith("... [truncated]")
+        assert statement["_truncated"] is True
+        assert statement["_originalLengthChars"] == len(long_statement)
+        assert statement["_returnedLengthChars"] == 50
+        assert statement["_returnedLengthChars"] == len(statement["value"])
+        assert statement["_fullStatementAvailableVia"] == {
+            "tool": "get_entities",
+            "arguments": {"urns": "urn:li:query:long-query"},
+        }

--- a/tests/test_mcp/test_get_entities_queries.py
+++ b/tests/test_mcp/test_get_entities_queries.py
@@ -84,6 +84,37 @@ def test_get_entities_with_query_urn(mock_client):
     assert len(result["subjects"]) == 1
 
 
+def test_get_entities_with_query_urn_preserves_full_statement(mock_client):
+    """The truncation hint's get_entities call returns the complete SQL text."""
+    query_urn = "urn:li:query:long-query"
+    long_statement = "SELECT * FROM orders WHERE customer_id IS NOT NULL " * 200
+    mock_response = {
+        "entity": {
+            "urn": query_urn,
+            "type": "QUERY",
+            "properties": {
+                "source": "MANUAL",
+                "statement": {"value": long_statement, "language": "SQL"},
+            },
+            "platform": {"name": "snowflake"},
+            "subjects": [],
+        }
+    }
+
+    mock_client._graph.exists.return_value = True
+    mock_client._graph.url_for = lambda x: f"https://example.com/{x}"
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.execute_graphql",
+        side_effect=[mock_response, {"entity": {}}],
+    ):
+        with with_datahub_client(mock_client):
+            result = get_entities(query_urn)
+
+    assert len(long_statement) > 5000
+    assert result["properties"]["statement"]["value"] == long_statement
+
+
 def test_get_entities_with_dataset_urn(mock_client):
     """Test that get_entities() uses GetEntity for non-Query URNs."""
 


### PR DESCRIPTION
### Summary

`get_dataset_queries` currently shortens SQL statements at the configured 5,000-character limit, but callers can only detect that by parsing the `... [truncated]` suffix.

This change adds explicit, additive metadata to every returned `properties.statement`:

- `_truncated`: whether `value` was shortened;
- `_originalLengthChars`: length of the original statement;
- `_returnedLengthChars`: length of the returned value, including the suffix when present.

When a statement is truncated, `_fullStatementAvailableVia` also provides the existing `get_entities` tool call for that query URN. This keeps `get_dataset_queries` bounded while giving callers an explicit path to request the full query only when needed. The current `value` and suffix behavior remain unchanged.

### Tests

- Added coverage for non-truncated statements and their exact lengths.
- Added coverage for truncated statements, exact lengths, suffix preservation, and the full-query retrieval hint.
- Added coverage proving that `get_entities(query_urn)` preserves the complete statement used by the hint.
- Full suite: `504 passed, 39 skipped`.
- Ruff formatting and lint checks pass.
- Mypy passes for all 36 checked source files.

### Compatibility

The response change is additive. Existing consumers still receive the same `properties.statement.value`, including the existing truncation suffix for long SQL.

### Risk

The three metadata fields add a small fixed amount to each query response, and the retrieval hint is present only for truncated statements. The hint deliberately points to the existing full-entity lookup, which may return more text; callers opt into that separate request.

## Verification record

- Base repository: `acryldata/mcp-server-datahub`
- Base commit: `9a6946daa7d30eb481c82dd8ee5e15ae6526a3c9` (`v0.6.0`)
- Focused tests: `12 passed`
- Full tests: `504 passed, 39 skipped`
- Ruff format check: passed (`65 files already formatted`)
- Ruff lint check: passed
- Mypy: passed (`36 source files`)
- `git diff --check`: passed
- Live DataHub test: not run; the 39 credential-dependent integration tests were skipped by the upstream suite.

## Upstream files changed

- `src/mcp_server_datahub/tools/dataset_queries.py`
- `tests/test_mcp/test_get_dataset_queries.py`
- `tests/test_mcp/test_get_entities_queries.py`