### PR TITLE
docs(tools): document prerequisites and supported types for mutation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ These tools allow modifying metadata in DataHub. They are enabled via the `TOOLS
 
 `add_tags` / `remove_tags`
 
-Add or remove tags from entities or schema fields (columns). Supports bulk operations on multiple entities.
+Add or remove tags from entities or schema fields (columns). Supports bulk operations on multiple entities. Tags are assigned, not created: every tag URN must already exist in DataHub, and there is no tag-creation tool — create missing tags via the DataHub UI or the Python SDK first.
 
 `add_terms` / `remove_terms`
 
@@ -116,11 +116,11 @@ Assign or remove domain membership for entities. Each entity can belong to one d
 
 `update_description`
 
-Update, append to, or remove descriptions for entities or schema fields. Supports markdown formatting.
+Update, append to, or remove descriptions for entities or schema fields. Supports markdown formatting. Only the entity types accepted by DataHub's `updateDescription` mutation are supported (dataset, container, domain, glossaryTerm, glossaryNode, tag, corpGroup, notebook, mlModel, mlModelGroup, mlFeatureTable, mlFeature, mlPrimaryKey, dataProduct, businessAttribute, application, document); others — including chart, dashboard, dataFlow, dataJob and corpuser — are rejected with `Unsupported resource type`.
 
 `add_structured_properties` / `remove_structured_properties`
 
-Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types.
+Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types. As with tags, the property definition must already exist in DataHub — these tools assign values, they do not define properties.
 
 ### User Tools
 

--- a/src/mcp_server_datahub/tools/descriptions.py
+++ b/src/mcp_server_datahub/tools/descriptions.py
@@ -19,9 +19,15 @@ def update_description(
     """Update description for a DataHub entity or its column (e.g., schema field).
 
     This tool allows you to set, append to, or remove a description for an entity or its column.
-    Useful for documenting datasets, containers, charts, dashboards, data flows, data jobs,
-    ML models, ML model groups, ML feature tables, ML primary keys, tags, glossary terms,
-    glossary nodes, domains, and schema fields.
+
+    Note: DataHub's updateDescription mutation only accepts a fixed set of entity types. Supported:
+    dataset (including its schema fields, via column_path), container, domain, glossaryTerm,
+    glossaryNode, tag, corpGroup, notebook, mlModel, mlModelGroup, mlFeatureTable, mlFeature,
+    mlPrimaryKey, dataProduct, businessAttribute, application, and document. Other types - including
+    chart, dashboard, dataFlow, dataJob, and corpuser - are rejected server-side with
+    "Failed to update description. Unsupported resource type <urn> provided.". The search tool
+    returns unsupported types alongside supported ones, so a bulk pass over search results should
+    filter by entity type first rather than relying on the error.
 
     Args:
         entity_urn: Entity URN to update description for (e.g., dataset URN, container URN)

--- a/src/mcp_server_datahub/tools/structured_properties.py
+++ b/src/mcp_server_datahub/tools/structured_properties.py
@@ -199,6 +199,13 @@ def add_structured_properties(
     This tool allows you to assign structured properties to multiple entities in a single operation.
     Structured properties are schema-defined metadata fields that can store typed values (strings, numbers, etc.).
 
+    Note: every key in property_values must be the URN of a structured property whose definition already
+    exists in DataHub. This tool only assigns values to existing definitions - it does not create them, and
+    this server exposes no property-definition tool. If a property URN does not exist, the call fails with
+    "Structured property URN does not exist in DataHub: ...". Values are also type-checked against the
+    definition's valueType, so the definition must be in place first. Find existing properties with the
+    search tool; create missing definitions out of band, e.g. via the DataHub UI or the Python SDK.
+
     Args:
         property_values: Dictionary mapping structured property URNs to lists of values.
                         Example: {

--- a/src/mcp_server_datahub/tools/tags.py
+++ b/src/mcp_server_datahub/tools/tags.py
@@ -174,6 +174,11 @@ def add_tags(
     Useful for bulk tagging operations like marking multiple datasets as PII, deprecated, or applying
     governance classifications.
 
+    Note: every URN in tag_urns must already exist in DataHub. This tool only assigns existing tags -
+    it does not create them, and this server exposes no tag-creation tool. If a tag URN does not exist,
+    the call fails with "The following tag URNs do not exist in DataHub: ...". Find existing tags with
+    the search tool (entity_type filter "TAG"); create missing ones out of band, e.g. via the DataHub
+    UI or the Python SDK, before calling this tool.
 
     Args:
         tag_urns: List of tag URNs to add (e.g., ["urn:li:tag:PII", "urn:li:tag:Sensitive"])


### PR DESCRIPTION
### What

Documentation-only change. Three constraints on the mutation tools are currently
discoverable only by making a call and reading the runtime error. This states them in the
tool docstrings (which are what the LLM actually sees as the tool description) and in the
README tool list.

1. **`add_tags` assigns existing tags; it does not create them.** `_validate_tag_urns`
   rejects any URN that is not already a `TAG` entity, and the server exposes no
   tag-creation tool (`tools/__init__.py`), so an integrator has to create tags out of band
   (UI or Python SDK) before the tool will work. This is a reasonable design; it just isn't
   written down anywhere an agent can read it.

2. **`add_structured_properties` has the same prerequisite**, one level deeper:
   `_validate_and_fetch_structured_property` requires the property *definition* to exist,
   and `_validate_property_value` type-checks the value against that definition's
   `valueType`. So the definition must be emitted first.

3. **`update_description` accepts only a fixed set of entity types**, and the docstring's
   current list does not match DataHub's resolver. `UpdateDescriptionResolver.java`
   switches on `targetUrn.getEntityType()` and throws
   `Failed to update description. Unsupported resource type %s provided.` in the default
   branch. Comparing that switch to the docstring:

   - listed as supported but **not** in the switch: `chart`, `dashboard`, `dataFlow`, `dataJob`
   - in the switch but **not** listed: `corpGroup`, `notebook`, `mlFeature`, `dataProduct`,
     `businessAttribute`, `application`, `document`

   Since `search` happily returns `dataFlow` / `corpuser` / `chart` alongside datasets, an
   agent doing a bulk documentation pass over search results will hit this. The docstring
   now carries the resolver's list plus a note to filter by entity type rather than relying
   on the error.

### How this was found

While building an agent that does a search → read → remediate → verify loop over a live
`datahub docker quickstart` v1.7.0 instance. Each item cost a debugging cycle that a line
of docstring would have avoided. `dataFlow` and `corpuser` were observed rejected in that
run while `mlFeature` and `corpGroup` were accepted, which matches the resolver switch
exactly.

### Note on item 3

The supported-type list is taken from `UpdateDescriptionResolver` on `datahub-project/datahub`
`master` and corroborated by the live OSS run above. If DataHub Cloud's resolver accepts
additional types (`chart` / `dashboard` / `dataJob` would be the obvious candidates given
the previous docstring), say so and I'll adjust the wording — I only have OSS to verify
against.

### Testing

`make lint-check` passes (`ruff format --check`, `ruff check`, `mypy`). No code paths
changed; nothing but docstrings and README prose.