### PR TITLE
feat: add idempotent ensure_tag mutation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Retrieve the exact lineage paths between two assets or columns, including interm
 
 These tools allow modifying metadata in DataHub. They are enabled via the `TOOLS_IS_MUTATION_ENABLED=true` environment variable.
 
+`ensure_tag`
+
+Ensures a tag definition exists in DataHub before it is applied with `add_tags`. The operation is idempotent. Typical workflow: `ensure_tag` -> `add_tags`.
+
 `add_tags` / `remove_tags`
 
 Add or remove tags from entities or schema fields (columns). Supports bulk operations on multiple entities.

--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -92,7 +92,7 @@ from .tools.structured_properties import (
     add_structured_properties,
     remove_structured_properties,
 )
-from .tools.tags import add_tags, remove_tags
+from .tools.tags import add_tags, ensure_tag, remove_tags
 from .tools.terms import (
     add_glossary_terms,
     remove_glossary_terms,
@@ -232,6 +232,9 @@ def register_mutation_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None
     if not enabled:
         return
 
+    _register_tool(
+        mcp_instance, "ensure_tag", ensure_tag, tags={ToolType.MUTATION.value}
+    )
     _register_tool(mcp_instance, "add_tags", add_tags, tags={ToolType.MUTATION.value})
     _register_tool(
         mcp_instance, "remove_tags", remove_tags, tags={ToolType.MUTATION.value}

--- a/src/mcp_server_datahub/tools/__init__.py
+++ b/src/mcp_server_datahub/tools/__init__.py
@@ -13,7 +13,7 @@ from .structured_properties import (
     add_structured_properties,
     remove_structured_properties,
 )
-from .tags import add_tags, remove_tags
+from .tags import add_tags, ensure_tag, remove_tags
 from .terms import (
     add_glossary_terms,
     remove_glossary_terms,
@@ -25,6 +25,7 @@ __all__ = [
     "add_structured_properties",
     "add_tags",
     "enhanced_search",
+    "ensure_tag",
     "get_dataset_queries",
     "get_entities",
     "get_lineage",

--- a/src/mcp_server_datahub/tools/tags.py
+++ b/src/mcp_server_datahub/tools/tags.py
@@ -3,12 +3,59 @@
 import logging
 from typing import List, Literal, Optional
 
+from datahub.errors import SdkUsageError
 from datahub.sdk.main_client import DataHubClient
+from datahub.sdk.tag import Tag
 
 from .. import graphql_helpers
 from ..version_requirements import min_version
 
 logger = logging.getLogger(__name__)
+
+
+@min_version(cloud="0.3.16", oss="1.4.0")
+def ensure_tag(name: str, description: Optional[str] = None) -> dict:
+    """Ensure that a tag definition exists in DataHub.
+
+    The tag identifier is used as provided to construct its DataHub URN. If the
+    tag already exists, this operation leaves it unchanged, including its
+    description. Use the returned URN with add_tags to apply the tag to entities
+    or schema fields.
+
+    Args:
+        name: Tag identifier (for example, "PII" creates "urn:li:tag:PII").
+        description: Optional description used only when creating a new tag.
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating that the tag exists
+        - tag_urn: The tag's DataHub URN
+        - created: Whether this call created the tag
+    """
+    if not name or not name.strip():
+        raise ValueError("name cannot be empty")
+
+    client = graphql_helpers.get_datahub_client()
+    tag = Tag(name=name, description=description)
+    tag_urn = str(tag.urn)
+
+    try:
+        if client._graph.exists(tag_urn):
+            return {"success": True, "tag_urn": tag_urn, "created": False}
+
+        try:
+            client.entities.create(tag)
+        except SdkUsageError:
+            # EntityClient.create performs its own existence check. Another caller
+            # may have created the same deterministic tag URN between our check and
+            # its check; in that case the requested postcondition is already met.
+            if client._graph.exists(tag_urn):
+                return {"success": True, "tag_urn": tag_urn, "created": False}
+            raise
+
+        return {"success": True, "tag_urn": tag_urn, "created": True}
+    except Exception as e:
+        raise RuntimeError(f"Error ensuring tag {tag_urn}: {str(e)}") from e
 
 
 def _validate_tag_urns(client: DataHubClient, tag_urns: List[str]) -> None:

--- a/tests/test_mcp/test_mutation_tools.py
+++ b/tests/test_mcp/test_mutation_tools.py
@@ -1,0 +1,14 @@
+"""Tests for mutation tool registration."""
+
+from unittest.mock import MagicMock
+
+from datahub_integrations.mcp.mcp_server import register_mutation_tools
+
+
+def test_ensure_tag_unavailable_when_mutations_disabled(monkeypatch):
+    monkeypatch.setenv("TOOLS_IS_MUTATION_ENABLED", "false")
+    mcp = MagicMock()
+
+    register_mutation_tools(mcp)
+
+    mcp.tool.assert_not_called()

--- a/tests/test_mcp/tools/test_tags.py
+++ b/tests/test_mcp/tools/test_tags.py
@@ -1,8 +1,10 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from datahub.errors import SdkUsageError
+from datahub.sdk.tag import Tag
 
-from datahub_integrations.mcp.tools.tags import add_tags, remove_tags
+from datahub_integrations.mcp.tools.tags import add_tags, ensure_tag, remove_tags
 
 
 @pytest.fixture
@@ -12,6 +14,127 @@ def mock_datahub_client():
     mock_graph = Mock()
     mock_client._graph = mock_graph
     return mock_client
+
+
+def test_ensure_tag_creates_missing_tag(mock_datahub_client):
+    mock_datahub_client._graph.exists.return_value = False
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = ensure_tag(name="PII", description="Personally identifiable")
+
+    assert result == {
+        "success": True,
+        "tag_urn": "urn:li:tag:PII",
+        "created": True,
+    }
+    mock_datahub_client.entities.create.assert_called_once()
+    created_tag = mock_datahub_client.entities.create.call_args.args[0]
+    assert isinstance(created_tag, Tag)
+    assert created_tag.name == "PII"
+    assert created_tag.description == "Personally identifiable"
+
+
+def test_ensure_tag_returns_existing_without_modification(mock_datahub_client):
+    mock_datahub_client._graph.exists.return_value = True
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = ensure_tag(name="PII", description="Do not overwrite")
+
+    assert result == {
+        "success": True,
+        "tag_urn": "urn:li:tag:PII",
+        "created": False,
+    }
+    mock_datahub_client.entities.create.assert_not_called()
+
+
+def test_ensure_tag_is_idempotent(mock_datahub_client):
+    mock_datahub_client._graph.exists.side_effect = [False, True]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        first = ensure_tag(name="PII")
+        second = ensure_tag(name="PII")
+
+    assert first["created"] is True
+    assert second["created"] is False
+    mock_datahub_client.entities.create.assert_called_once()
+
+
+@pytest.mark.parametrize("name", ["", " ", "\t"])
+def test_ensure_tag_rejects_empty_name(name):
+    with pytest.raises(ValueError, match="name cannot be empty"):
+        ensure_tag(name=name)
+
+
+def test_ensure_tag_propagates_datahub_api_failure(mock_datahub_client):
+    api_error = ConnectionError("DataHub API unavailable")
+    mock_datahub_client._graph.exists.side_effect = api_error
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="DataHub API unavailable") as exc_info:
+            ensure_tag(name="PII")
+
+    assert exc_info.value.__cause__ is api_error
+
+
+def test_ensure_tag_propagates_permission_failure(mock_datahub_client):
+    permission_error = PermissionError("403 Forbidden: insufficient privileges")
+    mock_datahub_client._graph.exists.return_value = False
+    mock_datahub_client.entities.create.side_effect = permission_error
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(RuntimeError, match="403 Forbidden") as exc_info:
+            ensure_tag(name="PII")
+
+    assert exc_info.value.__cause__ is permission_error
+
+
+def test_ensure_tag_handles_concurrent_creation(mock_datahub_client):
+    mock_datahub_client._graph.exists.side_effect = [False, True]
+    mock_datahub_client.entities.create.side_effect = SdkUsageError(
+        "Entity urn:li:tag:PII already exists"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = ensure_tag(name="PII")
+
+    assert result["created"] is False
+    mock_datahub_client.entities.create.assert_called_once()
+
+
+def test_ensure_tag_does_not_attach_tag(mock_datahub_client):
+    mock_datahub_client._graph.exists.return_value = False
+
+    with (
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ),
+        patch(
+            "datahub_integrations.mcp.graphql_helpers.execute_graphql"
+        ) as execute_graphql,
+    ):
+        ensure_tag(name="PII")
+
+    execute_graphql.assert_not_called()
 
 
 def test_add_tags_to_multiple_datasets(mock_datahub_client):


### PR DESCRIPTION
## Summary

Mutation workflows using `add_tags` currently require the Tag entity to exist first.

This PR adds an idempotent `ensure_tag` mutation tool that:

- creates a missing tag definition
- returns the existing tag when already present
- does not attach the tag to assets
- remains behind the existing mutation-tools feature flag

## Motivation

This enables a safe agent workflow:

`ensure_tag` → `add_tags`

An agent can ensure the metadata definition exists without first implementing
its own out-of-band SDK bootstrap logic.

This addresses the tag-assignment workflow described in #145.

## Behavior

For a missing tag, `ensure_tag` creates the definition and returns
`created=true`.

For an existing tag, it returns `created=false` without creating a duplicate.

Both cases return the same tag URN.

Existing descriptions are not silently overwritten.

### Why a separate idempotent operation?

The tool keeps metadata-definition creation separate from metadata assignment:
`ensure_tag` manages the Tag entity, while the existing `add_tags` tool remains
responsible only for attaching tags to entities.

This preserves existing `add_tags` semantics and makes repeated agent
workflows safe.

## Testing

- Full unit suite: 512 passed
- Focused tag and mutation tests: 33 passed
- Ruff: pass
- mypy: pass
- Formatting: pass

Live validation against DataHub 1.7.0:

- missing tag created successfully
- repeated ensure returned `created=false`
- the same tag URN was returned
- `add_tags` succeeded immediately afterwards
- tag attachment was verified
- `remove_tags` cleanup was verified
- mutation-disabled server did not expose `ensure_tag`

## Scope

This intentionally does not introduce generic metadata-definition creation
and does not modify `add_tags` semantics.

## Issue

Addresses #145