### PR TITLE
fix: tag all registered write tools as mutations

### DIFF
--- a/src/mcp_server_datahub/mcp_server.py
+++ b/src/mcp_server_datahub/mcp_server.py
@@ -257,10 +257,23 @@ def register_mutation_tools(mcp_instance: FastMCP, is_oss: bool = False) -> None
     _register_tool(
         mcp_instance, "remove_domains", remove_domains, tags={ToolType.MUTATION.value}
     )
-    _register_tool(mcp_instance, "update_description", update_description)
-    _register_tool(mcp_instance, "add_structured_properties", add_structured_properties)
     _register_tool(
-        mcp_instance, "remove_structured_properties", remove_structured_properties
+        mcp_instance,
+        "update_description",
+        update_description,
+        tags={ToolType.MUTATION.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "add_structured_properties",
+        add_structured_properties,
+        tags={ToolType.MUTATION.value},
+    )
+    _register_tool(
+        mcp_instance,
+        "remove_structured_properties",
+        remove_structured_properties,
+        tags={ToolType.MUTATION.value},
     )
 
     # Register save_document tool (only if enabled via environment variable)

--- a/tests/test_mcp/test_mutation_tags.py
+++ b/tests/test_mcp/test_mutation_tags.py
@@ -1,0 +1,70 @@
+"""Every tool registered by ``register_mutation_tools`` writes to DataHub.
+
+The registration is the only place that says so. FastMCP's ``disable(tags=...)`` and
+the ``exclude_tags`` option in ``fastmcp.json`` both select on tags, so a write tool
+registered without ``ToolType.MUTATION`` stays exposed after an operator has asked for
+the mutation surface to be removed.
+
+These tests assert the invariant rather than a list of names, so a write tool added
+later cannot arrive untagged.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from datahub_integrations.mcp.fastmcp_helpers import list_mcp_tools_sync
+from datahub_integrations.mcp.mcp_server import (
+    ToolType,
+    register_mutation_tools,
+    register_search_tools,
+)
+
+MUTATION_TAG = ToolType.MUTATION.value
+
+
+def _mutation_server() -> FastMCP:
+    """A server carrying only the mutation surface, with every gate opened."""
+    mcp: FastMCP = FastMCP[None](name="test-mutations")
+    with patch.dict(
+        os.environ,
+        {"TOOLS_IS_MUTATION_ENABLED": "true", "SAVE_DOCUMENT_TOOL_ENABLED": "true"},
+    ):
+        register_mutation_tools(mcp)
+    return mcp
+
+
+def test_every_registered_mutation_tool_carries_the_mutation_tag() -> None:
+    tools = list_mcp_tools_sync(_mutation_server())
+
+    assert tools, "register_mutation_tools registered nothing; the gate did not open"
+
+    untagged = sorted(tool.name for tool in tools if MUTATION_TAG not in tool.tags)
+    assert untagged == [], (
+        f"write tools registered without the {MUTATION_TAG!r} tag: {untagged}"
+    )
+
+
+def test_disabling_the_mutation_tag_removes_every_write_tool() -> None:
+    """The consequence: tag-based filtering must leave no write tool behind."""
+    mcp = _mutation_server()
+    mcp.disable(tags={MUTATION_TAG})
+
+    remaining = sorted(tool.name for tool in list_mcp_tools_sync(mcp))
+    assert remaining == [], (
+        f"still exposed after disabling the {MUTATION_TAG!r} tag: {remaining}"
+    )
+
+
+@pytest.mark.parametrize("is_oss", [True, False])
+def test_read_tools_are_not_tagged_as_mutations(is_oss: bool) -> None:
+    """The tag must stay meaningful: reads carry it in neither deployment shape."""
+    mcp: FastMCP = FastMCP[None](name="test-reads")
+    register_search_tools(mcp, is_oss=is_oss)
+
+    mislabelled = sorted(
+        tool.name for tool in list_mcp_tools_sync(mcp) if MUTATION_TAG in tool.tags
+    )
+    assert mislabelled == [], f"read tools tagged as mutations: {mislabelled}"


### PR DESCRIPTION
## What

`register_mutation_tools` registers eleven write tools. Eight of them, plus `save_document`, pass `tags={ToolType.MUTATION.value}`. These three do not:

```python
_register_tool(mcp_instance, "update_description", update_description)
_register_tool(mcp_instance, "add_structured_properties", add_structured_properties)
_register_tool(
    mcp_instance, "remove_structured_properties", remove_structured_properties
)
```

All three issue GraphQL mutations — `updateDescription`, `upsertStructuredProperties`, `removeStructuredProperties` — so the omission looks like an oversight rather than a classification decision.

## Why it matters

The tag is how the mutation surface gets selected, in two places.

**Server-side filtering.** FastMCP 3 exposes `server.disable(tags=...)`, and `fastmcp.json` exposes `exclude_tags`. An operator who removes the mutation surface with `exclude_tags: ["mutation"]` keeps three write tools.

**Client-side classification.** The tags reach the client over the wire in `tools/list` as `_meta.fastmcp.tags`, so a client building a read-only allowlist from the advertised surface sees three write tools with no mutation classification. PR #177 proposes documenting exactly that post-start `tools/list` check as the production read-only pattern.

This is not an authorization bypass and I am not reporting it as one. `TOOLS_IS_MUTATION_ENABLED` still gates the whole function, and DataHub still enforces its own permissions on the token. What breaks is the classification: a supported filtering mechanism does not remove tools it is asked to remove.

`readOnlyHint` (#105) is unaffected. None of the three carries `@read_only`, which is correct.

## Reproduction

On unmodified `main`, with `TOOLS_IS_MUTATION_ENABLED=true`, listing tools through an MCP client:

```
add_owners                       tags=['mutation']
add_structured_properties        tags=[]
add_tags                         tags=['mutation']
add_terms                        tags=['mutation']
remove_domains                   tags=['mutation']
remove_owners                    tags=['mutation']
remove_structured_properties     tags=[]
remove_tags                      tags=['mutation']
remove_terms                     tags=['mutation']
save_document                    tags=['mutation']
set_domains                      tags=['mutation']
update_description               tags=[]
```

After this change, every row reads `tags=['mutation']`.

And the filtering consequence, on `main`:

```
>>> mcp.disable(tags={"mutation"})
>>> [t.name for t in list_mcp_tools_sync(mcp)]
['add_structured_properties', 'remove_structured_properties', 'update_description']
```

After this change, that list is empty.

## The change

Adds `tags={ToolType.MUTATION.value}` to the three registrations. No behaviour outside tool metadata changes.

## Tests

`tests/test_mcp/test_mutation_tags.py`, three cases:

1. Every tool registered by `register_mutation_tools` carries the mutation tag. Asserted as an invariant over the registered set rather than a list of names, so a write tool added later cannot arrive untagged.
2. `disable(tags={"mutation"})` leaves no tool behind. This is the consequence rather than the label.
3. Read tools registered by `register_search_tools` are *not* tagged as mutations, in both `is_oss=True` and `is_oss=False`. Without this, tagging everything would pass test 1.

On unmodified `main`, 1 and 2 fail naming exactly those three tools and 3 passes. With the change, all three pass.

The test uses the `datahub_integrations.mcp` import path, like `tests/test_mcp/test_read_only.py`, so it works in both repositories this file is synced between.

## Validation

```
uv run pytest tests/test_mcp     503 passed
make lint-check                  ruff format, ruff check, mypy all clean
```

I did not run `tests/test_mcp_integration.py`. It asserts against the `datahub docker ingest-sample-data` fixture, which the instance I have here does not carry, and this change is registration metadata that the offline tests cover directly. CI runs it against OSS quickstart and Cloud.

## Compatibility

Additive metadata only. A deployment filtering on `tags={"mutation"}` will now correctly stop exposing these three tools, which is the intent of setting that filter. Anyone who had come to rely on the three surviving a mutation filter would be relying on the bug.

`mcp_server.py` is synced between two repositories, so this needs the same three-line change on the other side.

---

Found while building a read-only operator agent on top of this server, where the allowlist was constructed from the advertised tool surface. Licet, an Apache-2.0 entry to Build with DataHub: The Agent Hackathon.
