### PR TITLE
fix(descriptions): treat a null aspect as absent when reading a description

### DIFF
--- a/src/mcp_server_datahub/tools/descriptions.py
+++ b/src/mcp_server_datahub/tools/descriptions.py
@@ -194,11 +194,13 @@ def update_description(
                 operation_name="getEntity",
             )
 
-            entity_data = result.get("entity", {})
+            # GraphQL returns an explicit null for an unset aspect, so `.get(key, {})`
+            # yields None rather than the default. Use `or {}` throughout.
+            entity_data = result.get("entity") or {}
             if column_path:
                 # Get column description
-                schema_metadata = entity_data.get("schemaMetadata", {})
-                fields = schema_metadata.get("fields", [])
+                schema_metadata = entity_data.get("schemaMetadata") or {}
+                fields = schema_metadata.get("fields") or []
                 for field in fields:
                     if field.get("fieldPath") == column_path:
                         existing_description = field.get("description", "")
@@ -206,13 +208,13 @@ def update_description(
             else:
                 # Get entity description
                 # Try editableProperties first (for Dataset, Container, etc.)
-                editable_props = entity_data.get("editableProperties", {})
-                existing_description = editable_props.get("description", "")
+                editable_props = entity_data.get("editableProperties") or {}
+                existing_description = editable_props.get("description") or ""
 
                 # If not found, try properties (for Tag, GlossaryTerm, etc.)
                 if not existing_description:
-                    properties = entity_data.get("properties", {})
-                    existing_description = properties.get("description", "")
+                    properties = entity_data.get("properties") or {}
+                    existing_description = properties.get("description") or ""
 
         except Exception as e:
             logger.warning(

--- a/src/mcp_server_datahub/tools/entities.py
+++ b/src/mcp_server_datahub/tools/entities.py
@@ -302,7 +302,7 @@ def list_schema_fields(
             )
 
         # Pre-compute matching count (need all fields for this)
-        fields_for_counting = result.get("schemaMetadata", {}).get("fields", [])
+        fields_for_counting = (result.get("schemaMetadata") or {}).get("fields", [])
         matching_count = sum(
             1 for field in fields_for_counting if score_field_by_keywords(field) > 0
         )

--- a/tests/test_mcp/tools/test_descriptions.py
+++ b/tests/test_mcp/tools/test_descriptions.py
@@ -593,3 +593,82 @@ def test_update_description_remove_glossary_term(mock_datahub_client):
     # Verify empty description was sent
     call_args = mock_datahub_client._graph.execute_graphql.call_args
     assert call_args.kwargs["variables"]["input"]["description"] == ""
+
+
+# Null-aspect tests: GraphQL returns an explicit null for an aspect that is not set,
+# so `.get(key, {})` yields None rather than the default.
+
+
+def test_update_description_append_with_null_editable_properties(
+    mock_datahub_client, caplog
+):
+    """Append on an entity whose editableProperties aspect is unset."""
+    entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
+    append_text = "Owned by the growth team."
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"editableProperties": None, "schemaMetadata": None}},
+        {"updateDescription": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_description(
+            entity_urn=entity_urn, operation="append", description=append_text
+        )
+
+    assert result["success"] is True
+    assert "Failed to fetch existing description" not in caplog.text
+
+    update_call = mock_datahub_client._graph.execute_graphql.call_args_list[1]
+    assert update_call.kwargs["variables"]["input"]["description"] == append_text
+
+
+def test_update_description_append_column_with_null_schema_metadata(
+    mock_datahub_client, caplog
+):
+    """Append on a column of an entity that has no schemaMetadata aspect."""
+    entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
+    append_text = "Primary key."
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": {"editableProperties": None, "schemaMetadata": None}},
+        {"updateDescription": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_description(
+            entity_urn=entity_urn,
+            operation="append",
+            description=append_text,
+            column_path="user_id",
+        )
+
+    assert result["success"] is True
+    assert "Failed to fetch existing description" not in caplog.text
+
+
+def test_update_description_append_with_null_entity(mock_datahub_client, caplog):
+    """Append when the entity lookup itself returns null."""
+    entity_urn = "urn:li:container:12345"
+
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {"entity": None},
+        {"updateDescription": True},
+    ]
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        result = update_description(
+            entity_urn=entity_urn, operation="append", description="New text"
+        )
+
+    assert result["success"] is True
+    assert "Failed to fetch existing description" not in caplog.text


### PR DESCRIPTION
## What

GraphQL returns an explicit `null` for an aspect that is not set, so `.get(key, {})` yields
`None` rather than the default and the chained `.get` raises `AttributeError`.

`list_schema_fields` already handles this. `entities.py:222` uses `or {}`, and
`test_handles_entity_with_null_schema` covers it with a docstring that states the rule
outright:

> The key difference from 'missing' is that `.get("schemaMetadata", {})` returns None (not
> `{}`), so we need the `or {}` guard.

The same shape reaches `update_description`, where that guard was never applied.

## Why it is worth fixing even though nothing crashes

In `update_description` the read sits inside a broad `except Exception`, so the failure is
swallowed. The only symptom is a warning that misdescribes what happened, on a completely
ordinary entity — a dataset whose documentation has simply never been edited, so
`editableProperties` comes back null:

```
Failed to fetch existing description for urn:li:dataset:(...): 'NoneType' object has no attribute 'get'
```

Nothing is lost — `existing_description` falls back to `""`, which is the right answer here —
but the log says the lookup failed when the entity was fine, and the same line without a
surrounding `try` is what makes this a hard `AttributeError` elsewhere.

## Changes

| File | Line | Reachable? |
|---|---|---|
| `tools/descriptions.py` | `result.get("entity", {})` | yes — entity lookup returns null |
| `tools/descriptions.py` | `entity_data.get("schemaMetadata", {})` | yes — column path, entity with no schema |
| `tools/descriptions.py` | `entity_data.get("editableProperties", {})` | yes — entity path, never-edited entity |
| `tools/entities.py` | `result.get("schemaMetadata", {})` at 305 | **no** — see below |

The `entities.py` change is not a fix. The `total_fields == 0` early return already guards
that path. It is included only so the identical expression reads the same way twice within one
function, since line 222 right above it uses `or {}`. Happy to drop it if you would rather keep
the diff to the reachable cases.

I deliberately did **not** sweep the rest of the repo for this pattern. There are ~20 further
instances of `.get(key, {})` on GraphQL responses in `lineage.py`, `documents.py`,
`structured_properties.py` and others; most look unreachable and auditing them properly is a
separate piece of work from this one.

## Tests

Three regression tests in `tests/test_mcp/tools/test_descriptions.py`, one per reachable call
site. Each asserts the operation succeeds *and* that no `Failed to fetch existing description`
warning was logged, since a passing assertion alone would not catch this — the exception is
swallowed, so the tool returns the right answer either way. The warning is the observable.

```
on main:        3 failed, 23 passed
with this PR:   26 passed
full suite:     504 passed  (pytest tests/ --ignore=tests/test_mcp_integration.py)
make lint-check: ruff format, ruff check, mypy — all clean
```

Integration tests not run locally; they need a live quickstart.

## Notes

Found while building a governance tool against the agent-context tools — I hit the unguarded
version of this line first, as an `AttributeError` out of `list_schema_fields` on
`datahub-agent-context` 1.7.0, which still ships the pre-`or {}` code. Filing that separately.
