### PR TITLE
fix(descriptions): reject unknown column paths

### DIFF
--- a/src/mcp_server_datahub/tools/descriptions.py
+++ b/src/mcp_server_datahub/tools/descriptions.py
@@ -99,9 +99,10 @@ def update_description(
             f"Invalid operation '{operation}'. Must be 'replace', 'append', or 'remove'"
         )
 
-    # For append operation, we need to fetch existing description first
+    # Appends need the current description. Column-level writes also need the
+    # schema so a missing field cannot be reported as a successful mutation.
     existing_description = ""
-    if operation == "append":
+    if operation == "append" or column_path:
         # Query to get existing description
         query = """
             query getEntity($urn: String!) {
@@ -186,6 +187,7 @@ def update_description(
             }
         """
 
+        matching_field = None
         try:
             result = graphql_helpers.execute_graphql(
                 client._graph,
@@ -194,16 +196,23 @@ def update_description(
                 operation_name="getEntity",
             )
 
-            entity_data = result.get("entity", {})
+            entity_data = result.get("entity") or {}
             if column_path:
-                # Get column description
-                schema_metadata = entity_data.get("schemaMetadata", {})
-                fields = schema_metadata.get("fields", [])
-                for field in fields:
-                    if field.get("fieldPath") == column_path:
-                        existing_description = field.get("description", "")
-                        break
-            else:
+                schema_metadata = entity_data.get("schemaMetadata") or {}
+                fields = schema_metadata.get("fields") or []
+                matching_field = next(
+                    (
+                        field
+                        for field in fields
+                        if field.get("fieldPath") == column_path
+                    ),
+                    None,
+                )
+                if operation == "append":
+                    existing_description = (
+                        matching_field.get("description") if matching_field else ""
+                    ) or ""
+            elif operation == "append":
                 # Get entity description
                 # Try editableProperties first (for Dataset, Container, etc.)
                 editable_props = entity_data.get("editableProperties", {})
@@ -215,10 +224,20 @@ def update_description(
                     existing_description = properties.get("description", "")
 
         except Exception as e:
+            if column_path:
+                raise RuntimeError(
+                    f"Failed to validate column_path '{column_path}' on {entity_urn}: {e}"
+                ) from e
             logger.warning(
                 f"Failed to fetch existing description for {entity_urn}: {e}. Will treat as empty."
             )
             existing_description = ""
+
+        if column_path and matching_field is None:
+            raise ValueError(
+                f"column_path '{column_path}' does not exist on {entity_urn}. "
+                "Verify the target dataset and column path before retrying."
+            )
 
     # Determine final description based on operation
     if operation == "append":

--- a/tests/test_mcp/tools/test_descriptions.py
+++ b/tests/test_mcp/tools/test_descriptions.py
@@ -52,9 +52,16 @@ def test_update_description_replace_column(mock_datahub_client):
     entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
     column_path = "email"
 
-    mock_datahub_client._graph.execute_graphql.return_value = {
-        "updateDescription": True
-    }
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entity": {
+                "schemaMetadata": {
+                    "fields": [{"fieldPath": column_path, "description": ""}]
+                }
+            }
+        },
+        {"updateDescription": True},
+    ]
 
     with patch(
         "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
@@ -72,9 +79,57 @@ def test_update_description_replace_column(mock_datahub_client):
     assert result["column_path"] == column_path
 
     # Verify subResource fields are set for column-level descriptions
-    call_args = mock_datahub_client._graph.execute_graphql.call_args
+    assert mock_datahub_client._graph.execute_graphql.call_count == 2
+    call_args = mock_datahub_client._graph.execute_graphql.call_args_list[1]
     assert call_args.kwargs["variables"]["input"]["subResource"] == "email"
     assert call_args.kwargs["variables"]["input"]["subResourceType"] == "DATASET_FIELD"
+
+
+def test_update_description_append_rejects_missing_column(mock_datahub_client):
+    """Test that a missing column fails before the mutation is attempted."""
+    entity_urn = "urn:li:dataset:(urn:li:dataPlatform:duckdb,db.schema.users,PROD)"
+
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {"schemaMetadata": None}
+    }
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(ValueError, match="column_path 'email' does not exist"):
+            update_description(
+                entity_urn=entity_urn,
+                operation="append",
+                description="test",
+                column_path="email",
+            )
+
+    assert mock_datahub_client._graph.execute_graphql.call_count == 1
+
+
+def test_update_description_replace_column_validation_failure(mock_datahub_client):
+    """Test that schema lookup failures do not fall through to the mutation."""
+    entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.users,PROD)"
+    mock_datahub_client._graph.execute_graphql.side_effect = Exception(
+        "GMS unavailable"
+    )
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(
+            RuntimeError, match="Failed to validate column_path 'email'"
+        ):
+            update_description(
+                entity_urn=entity_urn,
+                operation="replace",
+                description="User email",
+                column_path="email",
+            )
+
+    assert mock_datahub_client._graph.execute_graphql.call_count == 1
 
 
 def test_update_description_replace_with_markdown(mock_datahub_client):
@@ -241,9 +296,16 @@ def test_update_description_remove_from_column(mock_datahub_client):
     entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
     column_path = "old_field"
 
-    mock_datahub_client._graph.execute_graphql.return_value = {
-        "updateDescription": True
-    }
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entity": {
+                "schemaMetadata": {
+                    "fields": [{"fieldPath": column_path, "description": "Old"}]
+                }
+            }
+        },
+        {"updateDescription": True},
+    ]
 
     with patch(
         "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
@@ -256,7 +318,8 @@ def test_update_description_remove_from_column(mock_datahub_client):
     assert result["success"] is True
 
     # Verify subResource fields are set for column-level
-    call_args = mock_datahub_client._graph.execute_graphql.call_args
+    assert mock_datahub_client._graph.execute_graphql.call_count == 2
+    call_args = mock_datahub_client._graph.execute_graphql.call_args_list[1]
     assert call_args.kwargs["variables"]["input"]["subResource"] == "old_field"
 
 


### PR DESCRIPTION
## Summary

- validate column-level description writes against `schemaMetadata.fields`
- reject an unknown `column_path` before calling the mutation
- fail closed when the schema lookup cannot be completed

## Why

When a dataset exists but does not carry schema metadata, `update_description`
could return `success: true` for a column-level write even though DataHub changed
nothing. This is easy to trigger with the target-platform sibling created by a
dbt ingestion.

The preflight keeps entity-level behavior unchanged. Valid column writes still
continue to `updateDescription`, while missing columns now produce a clear error
instead of a false success.

Closes #200.

## Testing

- `UV_CACHE_DIR=.uv-cache make lint-check`
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_mcp/tools/test_descriptions.py -q` (`25 passed`)
- `UV_CACHE_DIR=.uv-cache uv run pytest -q` (`503 passed, 39 skipped`)

