### PR TITLE
fix: get_entities missing ownership field for GlossaryTerm

### DIFF
--- a/src/mcp_server_datahub/gql/entity_details.gql
+++ b/src/mcp_server_datahub/gql/entity_details.gql
@@ -811,6 +811,9 @@ fragment entityPreview on Entity {
                 value
             }
         }
+        ownership {
+            ...ownershipFields
+        }
         deprecation {
             ...deprecationFields
         }


### PR DESCRIPTION
## Summary

`get_entities` never returns the `ownership` aspect for `GlossaryTerm` entities, even when ownership is actually set on the term.

Every other major entity type's inline fragment in `entity_details.gql` requests `ownership { ...ownershipFields }` (`Dataset`, `Dashboard`, `DataFlow`, `DataJob`, `MLFeatureTable`, ...), but the `... on GlossaryTerm { ... }` fragment used by `get_entities` simply never lists the field:

```graphql
... on GlossaryTerm {
    hierarchicalName
    properties { name description termSource sourceRef sourceUrl rawSchema customProperties { key value } }
    deprecation { ...deprecationFields }
}
```

## Root cause

Confirmed this is a query-construction gap, not a data or resolver issue, by checking the same term at three layers:

1. Raw GMS REST (`GET /entitiesV2/{urn}?aspects=ownership`) → returns the real owner correctly.
2. Raw DataHub GraphQL (`POST /api/graphql`, same `ownership` selection) → resolves correctly.
3. `get_entities` MCP tool → `ownership` key absent from the response entirely.

Since GMS's GraphQL resolver already returns ownership correctly for `GlossaryTerm` when asked, the only thing missing is that `entity_details.gql`'s `GlossaryTerm` fragment never asks for it. There's a separate `glossaryTerm` fragment (line 174) that does include `ownership`, but that one's only used when a term shows up as a *related* reference off another entity — not when the term itself is the primary entity fetched via `get_entities`.

## Fix

Add the missing `ownership { ...ownershipFields }` field to the `GlossaryTerm` inline fragment in `entity_details.gql`, consistent with every sibling entity type in the same file.

## Context

Ran into this building an agent that needs to resolve a glossary term's owner (to route a metadata conflict for human review). Had to work around it with a direct raw-REST call before tracking down the root cause here.

## Testing

- Verified locally against a running DataHub OSS quickstart instance: after this change, `get_entities` on a `GlossaryTerm` urn with a configured owner now returns the `ownership` block.
- Checked existing tests (`tests/test_mcp/test_get_entities.py` and related) — none assert on `GlossaryTerm`-specific fields or snapshot the raw query text, so this is a low-risk, additive change.