### PR TITLE
fix: fail closed when update_description column_path matches no field

### DIFF
--- a/src/mcp_server_datahub/tools/descriptions.py
+++ b/src/mcp_server_datahub/tools/descriptions.py
@@ -99,9 +99,10 @@ def update_description(
             f"Invalid operation '{operation}'. Must be 'replace', 'append', or 'remove'"
         )
 
-    # For append operation, we need to fetch existing description first
+    # For append operation, we need to fetch the existing description first.
+    # Column-level operations also fetch the schema to confirm the field exists.
     existing_description = ""
-    if operation == "append":
+    if operation == "append" or column_path is not None:
         # Query to get existing description
         query = """
             query getEntity($urn: String!) {
@@ -194,15 +195,24 @@ def update_description(
                 operation_name="getEntity",
             )
 
-            entity_data = result.get("entity", {})
-            if column_path:
+            entity_data = result.get("entity") or {}
+            if column_path is not None:
                 # Get column description
-                schema_metadata = entity_data.get("schemaMetadata", {})
-                fields = schema_metadata.get("fields", [])
-                for field in fields:
-                    if field.get("fieldPath") == column_path:
-                        existing_description = field.get("description", "")
-                        break
+                schema_metadata = entity_data.get("schemaMetadata") or {}
+                fields = schema_metadata.get("fields") or []
+                matching_field = next(
+                    (
+                        field
+                        for field in fields
+                        if field.get("fieldPath") == column_path
+                    ),
+                    None,
+                )
+                if matching_field is None:
+                    raise ValueError(
+                        f"Column path '{column_path}' was not found on entity {entity_urn}"
+                    )
+                existing_description = matching_field.get("description", "")
             else:
                 # Get entity description
                 # Try editableProperties first (for Dataset, Container, etc.)
@@ -214,7 +224,13 @@ def update_description(
                     properties = entity_data.get("properties", {})
                     existing_description = properties.get("description", "")
 
+        except ValueError:
+            raise
         except Exception as e:
+            if column_path is not None:
+                raise RuntimeError(
+                    f"Error validating column path '{column_path}' for {entity_urn}: {e}"
+                ) from e
             logger.warning(
                 f"Failed to fetch existing description for {entity_urn}: {e}. Will treat as empty."
             )
@@ -245,7 +261,7 @@ def update_description(
     }
 
     # Add subresource fields if provided (for column-level descriptions)
-    if column_path:
+    if column_path is not None:
         variables["input"]["subResource"] = column_path
         variables["input"]["subResourceType"] = "DATASET_FIELD"
 

--- a/tests/test_mcp/tools/test_descriptions.py
+++ b/tests/test_mcp/tools/test_descriptions.py
@@ -52,9 +52,16 @@ def test_update_description_replace_column(mock_datahub_client):
     entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
     column_path = "email"
 
-    mock_datahub_client._graph.execute_graphql.return_value = {
-        "updateDescription": True
-    }
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entity": {
+                "schemaMetadata": {
+                    "fields": [{"fieldPath": column_path, "description": ""}]
+                }
+            }
+        },
+        {"updateDescription": True},
+    ]
 
     with patch(
         "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
@@ -72,7 +79,7 @@ def test_update_description_replace_column(mock_datahub_client):
     assert result["column_path"] == column_path
 
     # Verify subResource fields are set for column-level descriptions
-    call_args = mock_datahub_client._graph.execute_graphql.call_args
+    call_args = mock_datahub_client._graph.execute_graphql.call_args_list[1]
     assert call_args.kwargs["variables"]["input"]["subResource"] == "email"
     assert call_args.kwargs["variables"]["input"]["subResourceType"] == "DATASET_FIELD"
 
@@ -241,9 +248,16 @@ def test_update_description_remove_from_column(mock_datahub_client):
     entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
     column_path = "old_field"
 
-    mock_datahub_client._graph.execute_graphql.return_value = {
-        "updateDescription": True
-    }
+    mock_datahub_client._graph.execute_graphql.side_effect = [
+        {
+            "entity": {
+                "schemaMetadata": {
+                    "fields": [{"fieldPath": column_path, "description": ""}]
+                }
+            }
+        },
+        {"updateDescription": True},
+    ]
 
     with patch(
         "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
@@ -256,11 +270,44 @@ def test_update_description_remove_from_column(mock_datahub_client):
     assert result["success"] is True
 
     # Verify subResource fields are set for column-level
-    call_args = mock_datahub_client._graph.execute_graphql.call_args
+    call_args = mock_datahub_client._graph.execute_graphql.call_args_list[1]
     assert call_args.kwargs["variables"]["input"]["subResource"] == "old_field"
 
 
 # Validation tests
+
+
+@pytest.mark.parametrize("operation", ["replace", "append", "remove"])
+def test_update_description_rejects_unknown_column_path(mock_datahub_client, operation):
+    """Test that column-level updates fail when the schema field is absent."""
+    entity_urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.users,PROD)"
+    column_path = "missing_column"
+    mock_datahub_client._graph.execute_graphql.return_value = {
+        "entity": {
+            "schemaMetadata": {
+                "fields": [{"fieldPath": "email", "description": "Email address"}]
+            }
+        }
+    }
+    kwargs = {
+        "entity_urn": entity_urn,
+        "operation": operation,
+        "column_path": column_path,
+    }
+    if operation != "remove":
+        kwargs["description"] = "Test description"
+
+    with patch(
+        "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+        return_value=mock_datahub_client,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="Column path 'missing_column' was not found on entity",
+        ):
+            update_description(**kwargs)
+
+    assert mock_datahub_client._graph.execute_graphql.call_count == 1
 
 
 def test_update_description_empty_entity_urn(mock_datahub_client):


### PR DESCRIPTION
## Reproduction

Calling `update_description` with a `column_path` that is absent from the target dataset's `schemaMetadata.fields` returned `success: true`, even though DataHub did not persist a field description. This commonly occurs when callers select a target-platform sibling dataset without schema metadata.

Closes #200.

## Expected and actual behavior

Expected: column-level description updates report an error when `column_path` does not resolve to a schema field.

Actual: the tool reported a successful mutation for an unmatched column path.

## Fix

Before every column-level mutation, fetch the entity schema and verify that the requested field path exists. An unmatched path now raises a clear `ValueError` and skips the mutation. Existing valid replace, append, and remove operations still use the resolved field.

## Test plan

- `uv run ruff format src/mcp_server_datahub/tools/descriptions.py tests/test_mcp/tools/test_descriptions.py`
- `uv run ruff check src/mcp_server_datahub/tools/descriptions.py tests/test_mcp/tools/test_descriptions.py`
- `uv run pytest tests/test_mcp/tools/test_descriptions.py`

Added coverage for unmatched column paths across replace, append, and remove, including verification that only the schema lookup runs and no mutation is issued.

Made with [Cursor](https://cursor.com)