### PR TITLE
fix(save_document): reject missing document URNs

### DIFF
--- a/src/mcp_server_datahub/tools/save_document.py
+++ b/src/mcp_server_datahub/tools/save_document.py
@@ -563,6 +563,34 @@ def save_document(
                 "author": None,
             }
 
+        try:
+            existing_document = client.entities.get(urn)
+        except Exception as e:
+            logger.error(
+                f"Failed to verify document exists before updating '{urn}': {e}",
+                exc_info=True,
+            )
+            return {
+                "success": False,
+                "urn": None,
+                "message": (
+                    f"Could not verify that document '{urn}' exists. "
+                    "The document was not updated."
+                ),
+                "author": None,
+            }
+
+        if existing_document is None:
+            return {
+                "success": False,
+                "urn": None,
+                "message": (
+                    f"Document '{urn}' was not found. "
+                    "Provide no urn to create a new document."
+                ),
+                "author": None,
+            }
+
         # Validate that the document is within the agent-authored hierarchy
         # This prevents accidental modification of user-created or imported documents
         if _restrict_updates_to_shared_folder():

--- a/tests/test_mcp/tools/test_save_document.py
+++ b/tests/test_mcp/tools/test_save_document.py
@@ -302,6 +302,33 @@ class TestSaveDocument:
         assert result["urn"] == existing_urn
         assert "updated" in result["message"].lower()
 
+    def test_save_document_missing_urn_returns_not_found(self, mock_datahub_client):
+        """Test that updating a missing document fails without upserting."""
+        missing_urn = "urn:li:document:agent-insight-missing-abc123"
+        mock_datahub_client.entities.get.return_value = None
+
+        with patch(
+            "datahub_integrations.mcp.graphql_helpers.get_datahub_client",
+            return_value=mock_datahub_client,
+        ):
+            result = save_document(
+                document_type="Insight",
+                title="Missing Document",
+                content="This must not be created.",
+                urn=missing_urn,
+            )
+
+        assert result == {
+            "success": False,
+            "urn": None,
+            "message": (
+                f"Document '{missing_urn}' was not found. "
+                "Provide no urn to create a new document."
+            ),
+            "author": None,
+        }
+        mock_datahub_client.entities.upsert.assert_not_called()
+
     def test_save_document_invalid_urn_format(self, mock_datahub_client):
         """Test that invalid URN format returns error."""
         with patch(


### PR DESCRIPTION
## Summary
- reject `save_document` update requests when the supplied document URN does not exist
- return a clear not-found response that tells callers to omit `urn` when creating a new document
- cover the missing-entity path and verify no upsert is attempted

Closes #211

## Test plan
- [x] `uv run ruff format --check src/mcp_server_datahub/tools/save_document.py tests/test_mcp/tools/test_save_document.py`
- [x] `uv run ruff check src/mcp_server_datahub/tools/save_document.py tests/test_mcp/tools/test_save_document.py`
- [x] `uv run mypy src/mcp_server_datahub/tools/save_document.py`
- [x] `uv run pytest tests/test_mcp/tools/test_save_document.py`
